### PR TITLE
fix(security): unblock precommit baseline (go 1.26.5, suppress GO-2026-5932)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,7 @@ CVE-2022-31022
 
 # aws-sdk-go-v2 s3/eventstream DoS, upgrade pending — BRO-20006
 GHSA-xmrv-pmrh-hhx2
+
+# golang.org/x/crypto/openpgp unmaintained/unsafe by design, no fix version;
+# package not imported by this module (go mod why: not needed)
+GO-2026-5932

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- fix(security): unblock `make precommit` baseline. Bump `go` directive 1.26.4 → 1.26.5 to clear stdlib advisory GO-2026-5856 (osv-scanner). Suppress GO-2026-5932 (`golang.org/x/crypto/openpgp` unmaintained/unsafe, no fix version, package not imported) in `VULNCHECK_IGNORE` (govulncheck) and `.trivyignore` (trivy).
+
 ## v4.13.1
 
 - bump go 1.26.3 → 1.26.4

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint:
 vet:
 	go vet -mod=mod $(shell go list -mod=mod ./... | grep -v /vendor/)
 
-VULNCHECK_IGNORE ?= GO-2026-4923 GO-2026-4514 GO-2022-0470 GO-2026-4772 GO-2026-4771
+VULNCHECK_IGNORE ?= GO-2026-4923 GO-2026-4514 GO-2022-0470 GO-2026-4772 GO-2026-4771 GO-2026-5932
 
 # Known-benign govulncheck failure modes we swallow. golang.org/x/tools v0.46.0
 # panics on packages containing generic *types.TypeParam during SSA analysis

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bborbe/teamvault-utils/v4
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/bborbe/argument/v2 v2.12.27


### PR DESCRIPTION
## Problem

`make precommit` fails on `origin/master` — two dependency advisories block the security gate (and therefore all CI + dark-factory runs on this repo):

| Advisory | Flagged by | Package | Nature |
|---|---|---|---|
| **GO-2026-5856** | osv-scanner | Go **stdlib 1.26.4** | Real stdlib vuln, fixed in 1.26.5 |
| **GO-2026-5932** | govulncheck + trivy | `golang.org/x/crypto/openpgp` | Unmaintained/unsafe-by-design, **no fix version**; package **not imported** by this module (`go mod why`: not needed) |

## Fix

- Bump `go` directive `1.26.4` → `1.26.5` — clears GO-2026-5856.
- Suppress GO-2026-5932 in `VULNCHECK_IGNORE` (govulncheck) and `.trivyignore` (trivy), consistent with the 5 advisories already suppressed there. It's an unused, unfixable module-level advisory.

`make precommit` is green after the change (127 specs, lint/vet/osv/trivy clean).

## Why now

Unblocks the shared master baseline for everyone, and is a prerequisite for the in-progress `teamvault` CLI consolidation (v5) work.