### PR TITLE
chore: migrate module path to seibert-media/teamvault-cli

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "teamvault-utils",
+  "name": "teamvault-cli",
   "owner": {
     "name": "Benjamin Borbe"
   },
@@ -9,7 +9,7 @@
   },
   "plugins": [
     {
-      "name": "teamvault-utils",
+      "name": "teamvault-cli",
       "description": "Fetch TeamVault secrets (password, username, url, file) and set up the teamvault CLI, for humans and AI agents",
       "source": "./",
       "version": "5.0.2",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
-  "name": "teamvault-utils",
+  "name": "teamvault-cli",
   "description": "Fetch TeamVault secrets (password, username, url, file) and set up the teamvault CLI, for humans and AI agents",
   "version": "5.0.2",
   "author": {
     "name": "Benjamin Borbe"
   },
-  "homepage": "https://github.com/bborbe/teamvault-utils",
-  "repository": "https://github.com/bborbe/teamvault-utils",
+  "homepage": "https://github.com/seibert-media/teamvault-cli",
+  "repository": "https://github.com/seibert-media/teamvault-cli",
   "license": "BSD-2-Clause"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- chore(repo): the project is now company-owned at **`github.com/seibert-media/teamvault-cli`** (transferred from `github.com/bborbe/teamvault-utils`, IT-44264). Module path becomes `github.com/seibert-media/teamvault-cli/v5` — install with `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest`. The `teamvault` binary name and `cmd/teamvault` layout are unchanged; only Go library importers must update the import path. The Claude Code plugin is renamed `teamvault-utils` → `teamvault-cli` (the `teamvault` skill inside is unchanged); re-add via `claude plugin marketplace add seibert-media/teamvault-cli`.
+
 ## v5.0.3
 
 - refactor(library): move the Go library package from the module root into `pkg/` — import `github.com/bborbe/teamvault-utils/v5/pkg` (package `teamvault`), was `github.com/bborbe/teamvault-utils/v5`. Aligns the layout with the go-package-layout guide (all production code under `pkg/`; the module root now holds only `cmd/` and `pkg/`). The `teamvault` binary and its `go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest` install path are unchanged — only Go library importers must update the import path.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ensure:
 format:
 	find . -type f -name 'go.mod' -not -path './vendor/*' -exec go run github.com/shoenig/go-modtool@$(GO_MODTOOL_VERSION) -w fmt "{}" \;
 	find . -type f -name '*.go' -not -path './vendor/*' -exec gofmt -w "{}" +
-	go run github.com/incu6us/goimports-reviser/v3@$(GOIMPORTS_REVISER_VERSION) -project-name github.com/bborbe/teamvault-utils -format -excludes vendor ./...
+	go run github.com/incu6us/goimports-reviser/v3@$(GOIMPORTS_REVISER_VERSION) -project-name github.com/seibert-media/teamvault-cli -format -excludes vendor ./...
 	find . -type d -name vendor -prune -o -type f -name '*.go' -print0 | xargs -0 -n 10 go run github.com/segmentio/golines@$(GOLINES_VERSION) --max-len=100 -w
 
 .PHONY: generate

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# teamvault-utils
+# teamvault-cli
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/bborbe/teamvault-utils/v5.svg)](https://pkg.go.dev/github.com/bborbe/teamvault-utils/v5)
-[![CI](https://github.com/bborbe/teamvault-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/bborbe/teamvault-utils/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/bborbe/teamvault-utils/v5)](https://goreportcard.com/report/github.com/bborbe/teamvault-utils/v5)
+[![Go Reference](https://pkg.go.dev/badge/github.com/seibert-media/teamvault-cli/v5.svg)](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5)
+[![CI](https://github.com/seibert-media/teamvault-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/seibert-media/teamvault-cli/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/seibert-media/teamvault-cli/v5)](https://goreportcard.com/report/github.com/seibert-media/teamvault-cli/v5)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/seibert-media/teamvault-cli)
 
 A single command-line tool for reading secrets from [TeamVault](https://github.com/trustedsec/teamvault) — passwords, usernames, URLs, and files — by their lookup key. Built for humans at a terminal **and** AI coding agents (e.g. Claude Code), as a sanctioned alternative to the 1Password `op` CLI for TeamVault-managed credentials.
 
 ## Install
 
 ```bash
-go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest
+go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
 ```
 
 ## Quick start
@@ -60,16 +61,16 @@ Have the agent call `teamvault` for credentials instead of embedding secrets in 
 
 ## Claude Code Plugin
 
-teamvault-utils ships a Claude Code plugin — a `teamvault` skill that helps you (or an agent) set up the CLI and fetch secrets from a Claude Code session, with a hard rule to never write a secret into the conversation, a file, or a commit.
+teamvault-cli ships a Claude Code plugin — a `teamvault` skill that helps you (or an agent) set up the CLI and fetch secrets from a Claude Code session, with a hard rule to never write a secret into the conversation, a file, or a commit.
 
 ```bash
 # Install
-claude plugin marketplace add bborbe/teamvault-utils
-claude plugin install teamvault-utils
+claude plugin marketplace add seibert-media/teamvault-cli
+claude plugin install teamvault-cli
 
 # Update
-claude plugin marketplace update teamvault-utils
-claude plugin update teamvault-utils@teamvault-utils
+claude plugin marketplace update teamvault-cli
+claude plugin update teamvault-cli@teamvault-cli
 ```
 
 | Command | Description |
@@ -78,7 +79,7 @@ claude plugin update teamvault-utils@teamvault-utils
 
 ## Go library
 
-`teamvault-utils` is also a Go library — import `github.com/bborbe/teamvault-utils/v5/pkg` (package `teamvault`). See **[docs/library.md](docs/library.md)** and the [API reference](https://pkg.go.dev/github.com/bborbe/teamvault-utils/v5/pkg).
+`teamvault-cli` is also a Go library — import `github.com/seibert-media/teamvault-cli/v5/pkg` (package `teamvault`). See **[docs/library.md](docs/library.md)** and the [API reference](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5/pkg).
 
 ## Development
 

--- a/cmd/teamvault/main.go
+++ b/cmd/teamvault/main.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"github.com/bborbe/teamvault-utils/v5/pkg/cli"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/cli"
 )
 
 func main() {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ One binary, a handful of subcommands, and your secret never has to sit in plaint
 ## 1. Install
 
 ```bash
-go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest
+go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
 ```
 
 This puts a single `teamvault` binary on your `PATH` (in `$(go env GOPATH)/bin`). Verify:

--- a/docs/library.md
+++ b/docs/library.md
@@ -3,10 +3,10 @@
 `teamvault-utils` is also a Go library. Import it:
 
 ```bash
-go get github.com/bborbe/teamvault-utils/v5
+go get github.com/seibert-media/teamvault-cli/v5
 ```
 
-The library package lives at `github.com/bborbe/teamvault-utils/v5/pkg` (package `teamvault`). API reference: [pkg.go.dev](https://pkg.go.dev/github.com/bborbe/teamvault-utils/v5/pkg).
+The library package lives at `github.com/seibert-media/teamvault-cli/v5/pkg` (package `teamvault`). API reference: [pkg.go.dev](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5/pkg).
 
 ## The `Connector` interface
 
@@ -17,7 +17,7 @@ import (
     "context"
     "net/http"
 
-    teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
     libtime "github.com/bborbe/time"
 )
 
@@ -54,8 +54,8 @@ teamvault.NewDummyConnector()               // fixtures, for tests
 
 ```go
 import (
-    "github.com/bborbe/teamvault-utils/v5/pkg/factory"
-    teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+    "github.com/seibert-media/teamvault-cli/v5/pkg/factory"
+    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
     libtime "github.com/bborbe/time"
 )
 
@@ -88,8 +88,8 @@ Use the Counterfeiter mock or the dummy connector:
 
 ```go
 import (
-    teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-    "github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+    "github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 conn := &mocks.Connector{}

--- a/docs/releasing-teamvault-utils.md
+++ b/docs/releasing-teamvault-utils.md
@@ -8,7 +8,7 @@ Unlike `vault-cli` / `dark-factory` / `coding` which ship both a binary and a Cl
 
 | Surface | Versioned by | Consumed by | Bumped how |
 |---------|--------------|-------------|------------|
-| **Binary + library** | git tag `vX.Y.Z` + matching `## vX.Y.Z` section in `CHANGELOG.md` | `go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest`; downstream Go projects importing the library | Auto-tagged by the project's own dark-factory daemon (`autoRelease: true`) when a prompt completes and updates `## Unreleased` |
+| **Binary + library** | git tag `vX.Y.Z` + matching `## vX.Y.Z` section in `CHANGELOG.md` | `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest`; downstream Go projects importing the library | Auto-tagged by the project's own dark-factory daemon (`autoRelease: true`) when a prompt completes and updates `## Unreleased` |
 
 There is no plugin to maintain. No marketplace JSONs to align. The CHANGELOG top entry and the git tag are the only two version sources, and `autoRelease` keeps them in lockstep.
 
@@ -162,7 +162,7 @@ git push origin master "$NEXT_TAG"
 gh release view "$NEXT_TAG" 2>/dev/null || echo "no GitHub Release yet (optional — see below)"
 ```
 
-The git tag is sufficient for `go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@vX.Y.Z`. A GitHub Release object is separate (see next section).
+The git tag is sufficient for `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@vX.Y.Z`. A GitHub Release object is separate (see next section).
 
 ## GitHub Release (manual — when to surface a milestone)
 
@@ -192,15 +192,15 @@ Verify on github.com → Releases tab. The Release object can be edited (notes, 
 
 ```bash
 # Operator local install (single binary, all subcommands)
-go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest
+go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
 teamvault --help 2>&1 | head -1  # sanity check
 
 # Downstream / fresh machine:
-go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@vX.Y.Z
+go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@vX.Y.Z
 
 # Library import (downstream Go projects):
-#   go.mod: require github.com/bborbe/teamvault-utils/v5 vX.Y.Z
-#   import: github.com/bborbe/teamvault-utils/v5/pkg
+#   go.mod: require github.com/seibert-media/teamvault-cli/v5 vX.Y.Z
+#   import: github.com/seibert-media/teamvault-cli/v5/pkg
 ```
 
 This is the step that bites downstream consumers if the gate was skipped. Other Go projects that import this library and any user's `teamvault` CLI on the next `go install` pick up the new binary. A regression in the new binary surfaces in their workflow, not yours.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bborbe/teamvault-utils/v5
+module github.com/seibert-media/teamvault-cli/v5
 
 go 1.26.5
 

--- a/pkg/api-url_test.go
+++ b/pkg/api-url_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("ApiUrl", func() {

--- a/pkg/cache-connector_test.go
+++ b/pkg/cache-connector_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("CacheConnector", func() {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -18,8 +18,8 @@ import (
 	libtime "github.com/bborbe/time"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/factory"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
 )
 
 // Execute runs the CLI application. It sets up signal handling for SIGINT and

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/bborbe/teamvault-utils/v5/pkg/cli"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/cli"
 )
 
 var _ = Describe("CLI", func() {

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bborbe/errors"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 // createConfigCommand creates the config parent command.

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("config parse", func() {

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -18,8 +18,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/factory"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
 )
 
 // connectorFactory creates a TeamVault connector given a context and password.

--- a/pkg/cli/login_test.go
+++ b/pkg/cli/login_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("loginFlow", func() {

--- a/pkg/config-parser_test.go
+++ b/pkg/config-parser_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Parser", func() {

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("Config", func() {

--- a/pkg/dummy-connector_test.go
+++ b/pkg/dummy-connector_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("", func() {

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -13,7 +13,7 @@ import (
 	libhttp "github.com/bborbe/http"
 	libtime "github.com/bborbe/time"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 // CreateConnectorWithConfig creates a new TeamVault Connector using configuration from a file or parameters.

--- a/pkg/factory/factory_integration_test.go
+++ b/pkg/factory/factory_integration_test.go
@@ -16,9 +16,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/factory"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Factory Integration", func() {

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -15,9 +15,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/factory"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Factory", func() {

--- a/pkg/keychain_impl_integration_test.go
+++ b/pkg/keychain_impl_integration_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("DarwinKeychain integration", func() {

--- a/pkg/keychain_impl_test.go
+++ b/pkg/keychain_impl_test.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/zalando/go-keyring"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("darwinKeychain", func() {

--- a/pkg/keychain_test.go
+++ b/pkg/keychain_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
-	"github.com/bborbe/teamvault-utils/v5/pkg/mocks"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Keychain", func() {

--- a/pkg/mocks/config_generator.go
+++ b/pkg/mocks/config_generator.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 type ConfigGenerator struct {

--- a/pkg/mocks/config_parser.go
+++ b/pkg/mocks/config_parser.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 type ConfigParser struct {

--- a/pkg/mocks/connector.go
+++ b/pkg/mocks/connector.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 type Connector struct {

--- a/pkg/mocks/keychain.go
+++ b/pkg/mocks/keychain.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 type Keychain struct {

--- a/pkg/mocks/keyring_client.go
+++ b/pkg/mocks/keyring_client.go
@@ -4,7 +4,7 @@ package mocks
 import (
 	"sync"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 type KeyringClient struct {

--- a/pkg/remote-connector_test.go
+++ b/pkg/remote-connector_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 
-	teamvault "github.com/bborbe/teamvault-utils/v5/pkg"
+	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("RemoteConnector", func() {

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -7,14 +7,14 @@ description: Fetch secrets (password, username, url, file) from TeamVault via th
 
 `teamvault` is a single CLI that reads secrets from the company TeamVault by their lookup key. Use it to hand a credential to a command (or to yourself) just-in-time, instead of storing secrets in `.env` files, prompts, or code — the sanctioned alternative to the 1Password `op` CLI for TeamVault-managed secrets.
 
-Full walkthrough for humans: `docs/getting-started.md` in the teamvault-utils repo.
+Full walkthrough for humans: `docs/getting-started.md` in the teamvault-cli repo.
 
 ## Prerequisites (check first, set up if missing)
 
 Run `teamvault --help`. If the command is missing:
 
 ```bash
-go install github.com/bborbe/teamvault-utils/v5/cmd/teamvault@latest   # installs to $(go env GOPATH)/bin
+go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest   # installs to $(go env GOPATH)/bin
 ```
 
 Config: `teamvault` needs a URL + username. Check for `~/.teamvault.json`:


### PR DESCRIPTION
First change after the IT-44264 ownership transfer of the repo to **seibert-media**.

## What
- Module path `github.com/bborbe/teamvault-utils/v5` → `github.com/seibert-media/teamvault-cli/v5` (go.mod + all imports + Makefile + docs + README + `skills/teamvault/SKILL.md`).
- Claude Code plugin renamed `teamvault-utils` → `teamvault-cli` (`.claude-plugin/` manifests). The `teamvault` skill inside is unchanged.
- Added an **Ask DeepWiki** badge (→ deepwiki.com/seibert-media/teamvault-cli), matching vault-cli / dark-factory.

## Unchanged
- The `teamvault` binary name and the `cmd/teamvault/` layout. Install becomes `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest` — same binary, so no consumer `.envrc` change.
- Historical CHANGELOG entries + completed `specs/`/`prompts/` keep their original `bborbe` paths (GitHub redirects handle them).

## Verification
`make precommit` green — 143 specs, lint/vet clean, osv/trivy clean, module path `…/seibert-media/teamvault-cli/v5` consistent throughout.

## Follow-ups (not in this PR)
- Install the maintainer GitHub App on this repo so the PR-review + autoRelease bots run here.
- Decide the first tag on the new path (continue `v5.x` vs reset) and release.
- Update the operator's `~/.claude/commands/teamvault.md` plugin ref + sweep consumer `.envrc` / vault notes.