### PR TITLE
chore: migrate module path to Seibert-Data/teamvault-cli

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Benjamin Borbe"
   },
-  "homepage": "https://github.com/seibert-media/teamvault-cli",
-  "repository": "https://github.com/seibert-media/teamvault-cli",
+  "homepage": "https://github.com/Seibert-Data/teamvault-cli",
+  "repository": "https://github.com/Seibert-Data/teamvault-cli",
   "license": "BSD-2-Clause"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- chore(repo): relocated to the **`Seibert-Data`** org — module path is now `github.com/Seibert-Data/teamvault-cli/v5`; install with `go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest`. (Was `github.com/seibert-media/teamvault-cli/v5` in v5.1.0; the seibert-media and bborbe URLs redirect.) Binary name, `cmd/teamvault` layout, and the `teamvault-cli` Keychain service are unchanged; only Go library importers update the import path.
 - change(keychain): rename the macOS Keychain service name `teamvault-utils` → `teamvault-cli`. After upgrading, run `teamvault login` once to store the password under the new service name. The old `teamvault-utils` entry is left intact, so a previously-installed `teamvault-utils` binary keeps working in parallel.
 - docs: finish the `teamvault-utils` → `teamvault-cli` rename in the plugin command, docs prose, scenario build paths, and the `docs/releasing-*` filename (the Go library import paths and module path already moved in v5.1.0).
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ensure:
 format:
 	find . -type f -name 'go.mod' -not -path './vendor/*' -exec go run github.com/shoenig/go-modtool@$(GO_MODTOOL_VERSION) -w fmt "{}" \;
 	find . -type f -name '*.go' -not -path './vendor/*' -exec gofmt -w "{}" +
-	go run github.com/incu6us/goimports-reviser/v3@$(GOIMPORTS_REVISER_VERSION) -project-name github.com/seibert-media/teamvault-cli -format -excludes vendor ./...
+	go run github.com/incu6us/goimports-reviser/v3@$(GOIMPORTS_REVISER_VERSION) -project-name github.com/Seibert-Data/teamvault-cli -format -excludes vendor ./...
 	find . -type d -name vendor -prune -o -type f -name '*.go' -print0 | xargs -0 -n 10 go run github.com/segmentio/golines@$(GOLINES_VERSION) --max-len=100 -w
 
 .PHONY: generate

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # teamvault-cli
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/seibert-media/teamvault-cli/v5.svg)](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5)
-[![CI](https://github.com/seibert-media/teamvault-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/seibert-media/teamvault-cli/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/seibert-media/teamvault-cli/v5)](https://goreportcard.com/report/github.com/seibert-media/teamvault-cli/v5)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/seibert-media/teamvault-cli)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Seibert-Data/teamvault-cli/v5.svg)](https://pkg.go.dev/github.com/Seibert-Data/teamvault-cli/v5)
+[![CI](https://github.com/Seibert-Data/teamvault-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/Seibert-Data/teamvault-cli/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Seibert-Data/teamvault-cli/v5)](https://goreportcard.com/report/github.com/Seibert-Data/teamvault-cli/v5)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Seibert-Data/teamvault-cli)
 
 A single command-line tool for reading secrets from [TeamVault](https://github.com/trustedsec/teamvault) — passwords, usernames, URLs, and files — by their lookup key. Built for humans at a terminal **and** AI coding agents (e.g. Claude Code), as a sanctioned alternative to the 1Password `op` CLI for TeamVault-managed credentials.
 
 ## Install
 
 ```bash
-go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
+go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest
 ```
 
 ## Quick start
@@ -65,7 +65,7 @@ teamvault-cli ships a Claude Code plugin — a `teamvault` skill that helps you 
 
 ```bash
 # Install
-claude plugin marketplace add seibert-media/teamvault-cli
+claude plugin marketplace add Seibert-Data/teamvault-cli
 claude plugin install teamvault-cli
 
 # Update
@@ -79,7 +79,7 @@ claude plugin update teamvault-cli@teamvault-cli
 
 ## Go library
 
-`teamvault-cli` is also a Go library — import `github.com/seibert-media/teamvault-cli/v5/pkg` (package `teamvault`). See **[docs/library.md](docs/library.md)** and the [API reference](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5/pkg).
+`teamvault-cli` is also a Go library — import `github.com/Seibert-Data/teamvault-cli/v5/pkg` (package `teamvault`). See **[docs/library.md](docs/library.md)** and the [API reference](https://pkg.go.dev/github.com/Seibert-Data/teamvault-cli/v5/pkg).
 
 ## Development
 

--- a/cmd/teamvault/main.go
+++ b/cmd/teamvault/main.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"github.com/seibert-media/teamvault-cli/v5/pkg/cli"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/cli"
 )
 
 func main() {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ One binary, a handful of subcommands, and your secret never has to sit in plaint
 ## 1. Install
 
 ```bash
-go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
+go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest
 ```
 
 This puts a single `teamvault` binary on your `PATH` (in `$(go env GOPATH)/bin`). Verify:

--- a/docs/library.md
+++ b/docs/library.md
@@ -3,10 +3,10 @@
 `teamvault-cli` is also a Go library. Import it:
 
 ```bash
-go get github.com/seibert-media/teamvault-cli/v5
+go get github.com/Seibert-Data/teamvault-cli/v5
 ```
 
-The library package lives at `github.com/seibert-media/teamvault-cli/v5/pkg` (package `teamvault`). API reference: [pkg.go.dev](https://pkg.go.dev/github.com/seibert-media/teamvault-cli/v5/pkg).
+The library package lives at `github.com/Seibert-Data/teamvault-cli/v5/pkg` (package `teamvault`). API reference: [pkg.go.dev](https://pkg.go.dev/github.com/Seibert-Data/teamvault-cli/v5/pkg).
 
 ## The `Connector` interface
 
@@ -17,7 +17,7 @@ import (
     "context"
     "net/http"
 
-    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+    teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
     libtime "github.com/bborbe/time"
 )
 
@@ -54,8 +54,8 @@ teamvault.NewDummyConnector()               // fixtures, for tests
 
 ```go
 import (
-    "github.com/seibert-media/teamvault-cli/v5/pkg/factory"
-    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+    "github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
+    teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
     libtime "github.com/bborbe/time"
 )
 
@@ -88,8 +88,8 @@ Use the Counterfeiter mock or the dummy connector:
 
 ```go
 import (
-    teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-    "github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+    teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+    "github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 conn := &mocks.Connector{}

--- a/docs/releasing-teamvault-cli.md
+++ b/docs/releasing-teamvault-cli.md
@@ -8,7 +8,7 @@ Unlike `vault-cli` / `dark-factory` / `coding` which ship both a binary and a Cl
 
 | Surface | Versioned by | Consumed by | Bumped how |
 |---------|--------------|-------------|------------|
-| **Binary + library** | git tag `vX.Y.Z` + matching `## vX.Y.Z` section in `CHANGELOG.md` | `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest`; downstream Go projects importing the library | Auto-tagged by the project's own dark-factory daemon (`autoRelease: true`) when a prompt completes and updates `## Unreleased` |
+| **Binary + library** | git tag `vX.Y.Z` + matching `## vX.Y.Z` section in `CHANGELOG.md` | `go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest`; downstream Go projects importing the library | Auto-tagged by the project's own dark-factory daemon (`autoRelease: true`) when a prompt completes and updates `## Unreleased` |
 
 There is no plugin to maintain. No marketplace JSONs to align. The CHANGELOG top entry and the git tag are the only two version sources, and `autoRelease` keeps them in lockstep.
 
@@ -162,7 +162,7 @@ git push origin master "$NEXT_TAG"
 gh release view "$NEXT_TAG" 2>/dev/null || echo "no GitHub Release yet (optional — see below)"
 ```
 
-The git tag is sufficient for `go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@vX.Y.Z`. A GitHub Release object is separate (see next section).
+The git tag is sufficient for `go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@vX.Y.Z`. A GitHub Release object is separate (see next section).
 
 ## GitHub Release (manual — when to surface a milestone)
 
@@ -192,15 +192,15 @@ Verify on github.com → Releases tab. The Release object can be edited (notes, 
 
 ```bash
 # Operator local install (single binary, all subcommands)
-go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest
+go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest
 teamvault --help 2>&1 | head -1  # sanity check
 
 # Downstream / fresh machine:
-go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@vX.Y.Z
+go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@vX.Y.Z
 
 # Library import (downstream Go projects):
-#   go.mod: require github.com/seibert-media/teamvault-cli/v5 vX.Y.Z
-#   import: github.com/seibert-media/teamvault-cli/v5/pkg
+#   go.mod: require github.com/Seibert-Data/teamvault-cli/v5 vX.Y.Z
+#   import: github.com/Seibert-Data/teamvault-cli/v5/pkg
 ```
 
 This is the step that bites downstream consumers if the gate was skipped. Other Go projects that import this library and any user's `teamvault` CLI on the next `go install` pick up the new binary. A regression in the new binary surfaces in their workflow, not yours.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/seibert-media/teamvault-cli/v5
+module github.com/Seibert-Data/teamvault-cli/v5
 
 go 1.26.5
 

--- a/pkg/api-url_test.go
+++ b/pkg/api-url_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("ApiUrl", func() {

--- a/pkg/cache-connector_test.go
+++ b/pkg/cache-connector_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("CacheConnector", func() {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -18,8 +18,8 @@ import (
 	libtime "github.com/bborbe/time"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
 )
 
 // Execute runs the CLI application. It sets up signal handling for SIGINT and

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/seibert-media/teamvault-cli/v5/pkg/cli"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/cli"
 )
 
 var _ = Describe("CLI", func() {

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bborbe/errors"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 // createConfigCommand creates the config parent command.

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("config parse", func() {

--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -18,8 +18,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
 )
 
 // connectorFactory creates a TeamVault connector given a context and password.

--- a/pkg/cli/login_test.go
+++ b/pkg/cli/login_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("loginFlow", func() {

--- a/pkg/config-parser_test.go
+++ b/pkg/config-parser_test.go
@@ -13,8 +13,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Parser", func() {

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("Config", func() {

--- a/pkg/dummy-connector_test.go
+++ b/pkg/dummy-connector_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("", func() {

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -13,7 +13,7 @@ import (
 	libhttp "github.com/bborbe/http"
 	libtime "github.com/bborbe/time"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 // CreateConnectorWithConfig creates a new TeamVault Connector using configuration from a file or parameters.

--- a/pkg/factory/factory_integration_test.go
+++ b/pkg/factory/factory_integration_test.go
@@ -16,9 +16,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Factory Integration", func() {

--- a/pkg/factory/factory_test.go
+++ b/pkg/factory/factory_test.go
@@ -15,9 +15,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/factory"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Factory", func() {

--- a/pkg/keychain_impl_integration_test.go
+++ b/pkg/keychain_impl_integration_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("DarwinKeychain integration", func() {

--- a/pkg/keychain_impl_test.go
+++ b/pkg/keychain_impl_test.go
@@ -14,8 +14,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/zalando/go-keyring"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("darwinKeychain", func() {

--- a/pkg/keychain_test.go
+++ b/pkg/keychain_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
-	"github.com/seibert-media/teamvault-cli/v5/pkg/mocks"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
 )
 
 var _ = Describe("Keychain", func() {

--- a/pkg/mocks/config_generator.go
+++ b/pkg/mocks/config_generator.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 type ConfigGenerator struct {

--- a/pkg/mocks/config_parser.go
+++ b/pkg/mocks/config_parser.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 type ConfigParser struct {

--- a/pkg/mocks/connector.go
+++ b/pkg/mocks/connector.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 type Connector struct {

--- a/pkg/mocks/keychain.go
+++ b/pkg/mocks/keychain.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sync"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 type Keychain struct {

--- a/pkg/mocks/keyring_client.go
+++ b/pkg/mocks/keyring_client.go
@@ -4,7 +4,7 @@ package mocks
 import (
 	"sync"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 type KeyringClient struct {

--- a/pkg/remote-connector_test.go
+++ b/pkg/remote-connector_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 
-	teamvault "github.com/seibert-media/teamvault-cli/v5/pkg"
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 )
 
 var _ = Describe("RemoteConnector", func() {

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -14,7 +14,7 @@ Full walkthrough for humans: `docs/getting-started.md` in the teamvault-cli repo
 Run `teamvault --help`. If the command is missing:
 
 ```bash
-go install github.com/seibert-media/teamvault-cli/v5/cmd/teamvault@latest   # installs to $(go env GOPATH)/bin
+go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest   # installs to $(go env GOPATH)/bin
 ```
 
 Config: `teamvault` needs a URL + username. Check for `~/.teamvault.json`:


### PR DESCRIPTION
Second relocation — the repo moved into the **Seibert-Data** org (where the Octopus review + release agents run), so it can be agent-managed as a normal Seibert-Data repo instead of needing a multi-org agent build.

## What
- Module path `github.com/seibert-media/teamvault-cli/v5` → `github.com/Seibert-Data/teamvault-cli/v5` (go.mod + all imports + Makefile + docs + README + DeepWiki badge + plugin manifests).

## Unchanged
- `teamvault` binary name + `cmd/teamvault/` layout → `go install github.com/Seibert-Data/teamvault-cli/v5/cmd/teamvault@latest`.
- The `teamvault-cli` Keychain service name.
- Historical CHANGELOG/specs/prompts keep their original `bborbe`/`seibert-media` paths (GitHub redirects handle them).

## Verification
`make precommit` green — 142 specs, lint/vet clean, osv/trivy clean, path `…/Seibert-Data/teamvault-cli/v5` consistent throughout.

## Ships with the pending `## Unreleased`
This PR + the already-merged keychain rename release together in the next tag (v5.2.0).