### PR TITLE
docs(changelog): promote Unreleased -> v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## v5.3.0
 
 - change(cli): the binary is now named **`teamvault-cli`** (was `teamvault`) — the entry point moved to the module root, so install is `go install github.com/Seibert-Data/teamvault-cli/v5@latest` (no more `/cmd/teamvault`). Update call sites: `teamvault password …` → `teamvault-cli password …`. The `TEAMVAULT_*` env/flag contract, the `~/.teamvault.json` config, and the Keychain service name are unchanged.
 - docs: add `CLAUDE.md` (agent-operational context — build, architecture, design decisions) and restructure `README.md` around usage scenarios (install, Claude Code plugin, configure, shell scripts, k8s config templating, AI agents).


### PR DESCRIPTION
Housekeeping after the hand-tagged **v5.3.0** (the  → TeamVault CLI for retrieving secrets

Usage:
  teamvault-cli [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config      Configuration templating commands
  file        Retrieve a file from TeamVault
  help        Help about any command
  login       Login to TeamVault and store credentials in the macOS Keychain
  password    Retrieve a password from TeamVault
  url         Retrieve a URL from TeamVault
  username    Retrieve a username from TeamVault

Flags:
      --cache                      enable teamvault secret cache
  -h, --help                       help for teamvault-cli
      --staging                    staging status
      --teamvault-config string    teamvault config file path
      --teamvault-pass string      teamvault password
      --teamvault-timeout string   HTTP request timeout for TeamVault API calls (e.g. 5s, 30s); 0 = default 5s
      --teamvault-url string       teamvault url
      --teamvault-user string      teamvault user

Use "teamvault-cli [command] --help" for more information about a command. command rename). The releaser classified the binary rename as major and halted; the module major stays `/v5`, so v5.3.0 was tagged by hand. Clears `## Unreleased` so the releaser stops re-halting. No code change.