### PR TITLE
feat(cli): add --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- feat(cli): add `--version` — `teamvault-cli --version` prints the release. Injected at build time via `-ldflags` (`make install`), with a `debug.ReadBuildInfo` fallback so `go install …/v5@vX.Y.Z` also reports the real module version.
+
 ## v5.3.0
 
 - change(cli): the binary is now named **`teamvault-cli`** (was `teamvault`) — the entry point moved to the module root, so install is `go install github.com/Seibert-Data/teamvault-cli/v5@latest` (no more `/cmd/teamvault`). Update call sites: `teamvault password …` → `teamvault-cli password …`. The `TEAMVAULT_*` env/flag contract, the `~/.teamvault.json` config, and the Keychain service name are unchanged.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 include tools.env
 
 GOPATH ?= $(shell go env GOPATH)
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X github.com/Seibert-Data/teamvault-cli/v5/pkg/cli.version=$(VERSION)
 
 .PHONY: default
 default: precommit
@@ -114,4 +116,4 @@ addlicense:
 
 .PHONY: install
 install:
-	go build -o $(GOPATH)/bin/teamvault-cli .
+	go build -ldflags "$(LDFLAGS)" -o $(GOPATH)/bin/teamvault-cli .

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/bborbe/errors"
@@ -21,6 +22,24 @@ import (
 	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
 	"github.com/Seibert-Data/teamvault-cli/v5/pkg/factory"
 )
+
+// version is injected at build time via -ldflags (see the Makefile). For a
+// plain `go install …@vX.Y.Z` build (no ldflags) it falls back to the module
+// version recorded in the binary's build info, so `--version` still reports the
+// real release.
+var version = "dev"
+
+func resolveVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if v := bi.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return version
+}
 
 // Execute runs the CLI application. It sets up signal handling for SIGINT and
 // SIGTERM, configures structured logging, and executes the root command.
@@ -73,6 +92,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           "teamvault-cli",
 		Short:         "TeamVault CLI for retrieving secrets",
+		Version:       resolveVersion(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}


### PR DESCRIPTION
Adds `teamvault-cli --version` (was `Error: unknown flag: --version`).

## How
- Cobra root command gets a `Version` field (auto-enables `--version`), sourced from `var version = "dev"` in `pkg/cli/cli.go`.
- Injected at build time via `-ldflags "-X …/pkg/cli.version=$(VERSION)"` where `VERSION = git describe --tags --always --dirty` (Makefile) — same pattern as vault-cli.
- **Fallback:** for a plain `go install …/v5@vX.Y.Z` (no ldflags), `resolveVersion()` reads `debug.ReadBuildInfo().Main.Version`, so `--version` still reports the real module version instead of `dev`.

## Verified
- `-ldflags …=v5.3.0-test` → `teamvault-cli version v5.3.0-test`
- plain `go build` → `teamvault-cli version v5.3.0+dirty` (VCS-stamped, no `dev`)
- `make precommit` green (143 specs).

Non-breaking additive feature → minor bump.