### PR TITLE
ci: goreleaser + Homebrew tap release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,32 @@ jobs:
         if: always()
         with:
           fail_ci_if_error: false
+
+  # Validate the release pipeline on every PR so a broken .goreleaser.yaml
+  # surfaces here, not only at tag-push. `build` skips the publish/brew steps,
+  # so no tokens are needed.
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Validate GoReleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: check
+
+      - name: Snapshot build (no publish)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: build --snapshot --clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,11 @@ jobs:
       - name: Validate GoReleaser config
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: 'v2.17.0'
           args: check
 
       - name: Snapshot build (no publish)
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: 'v2.17.0'
           args: build --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: 'v2.17.0'
           args: release --clean
         env:
           # builds the GitHub Release + archives on this repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,8 @@ jobs:
         env:
           # builds the GitHub Release + archives on this repo
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # pushes the generated Homebrew formula to Seibert-Data/homebrew-tap (cross-repo)
+          # Pushes the generated Homebrew formula to Seibert-Data/homebrew-tap (cross-repo).
+          # SECURITY: use a *fine-grained* PAT scoped to ONLY the homebrew-tap repo with
+          # Contents: Read and write (nothing else). This limits blast radius if the secret
+          # leaks — a compromised token can only touch the tap, not this repo or the org.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          # builds the GitHub Release + archives on this repo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # pushes the generated Homebrew formula to Seibert-Data/homebrew-tap (cross-repo)
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverprofile.out
 /teamvault-password
 /teamvault-url
 /teamvault-username
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,49 @@
+version: 2
+
+project_name: teamvault-cli
+
+builds:
+  - id: teamvault-cli
+    binary: teamvault-cli
+    main: .
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/Seibert-Data/teamvault-cli/v5/pkg/cli.version={{ .Tag }}
+
+archives:
+  - id: teamvault-cli
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  github:
+    owner: Seibert-Data
+    name: teamvault-cli
+
+brews:
+  - name: teamvault-cli
+    description: "Read secrets from TeamVault (passwords, usernames, URLs, files) by lookup key"
+    homepage: "https://github.com/Seibert-Data/teamvault-cli"
+    license: "BSD-2-Clause"
+    repository:
+      owner: Seibert-Data
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser@seibert.group
+    install: |
+      bin.install "teamvault-cli"
+    test: |
+      system "#{bin}/teamvault-cli", "--version"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,11 +31,10 @@ release:
     owner: Seibert-Data
     name: teamvault-cli
 
-brews:
+homebrew_casks:
   - name: teamvault-cli
     description: "Read secrets from TeamVault (passwords, usernames, URLs, files) by lookup key"
     homepage: "https://github.com/Seibert-Data/teamvault-cli"
-    license: "BSD-2-Clause"
     repository:
       owner: Seibert-Data
       name: homebrew-tap
@@ -43,7 +42,9 @@ brews:
     commit_author:
       name: goreleaser-bot
       email: goreleaser@seibert.group
-    install: |
-      bin.install "teamvault-cli"
-    test: |
-      system "#{bin}/teamvault-cli", "--version"
+    # The binary is unsigned; strip the download quarantine so it runs without a
+    # Gatekeeper "unidentified developer" prompt on first use.
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/teamvault-cli"]


### PR DESCRIPTION
Adds prebuilt-binary + Homebrew distribution so users (Martin) can `brew install` / `brew upgrade` instead of needing the Go toolchain.

## What
- **`.goreleaser.yaml`** — builds `darwin`/`linux` × `amd64`/`arm64` (pure-Go, `CGO_ENABLED=0`), `--version` baked via ldflags, publishes GitHub Release archives + checksums, and generates a Homebrew formula pushed to `Seibert-Data/homebrew-tap`.
- **`.github/workflows/release.yml`** — runs goreleaser on every `v*` tag (the octopus releaser already cuts these).
- `.gitignore`: ignore goreleaser's `dist/`.

Validated locally: `goreleaser check` passes; snapshot build compiles all 4 targets.

## Result (once set up)
```bash
brew install Seibert-Data/tap/teamvault-cli
brew upgrade            # rides the normal laptop update cycle
```

## One-time setup needed (org side — not in this PR)
1. Create the **`Seibert-Data/homebrew-tap`** repo (public).
2. Add a **`HOMEBREW_TAP_TOKEN`** repo secret on teamvault-cli — a token with write access to the tap repo (cross-repo push; the default `GITHUB_TOKEN` can't reach another repo).

The first goreleaser run happens on the **next** tag after this merges + setup is done.

## Note
goreleaser flags `brews` as deprecated in favour of `homebrew_casks`, but a **formula** (`brews`) is intentional here — casks quarantine unsigned binaries (Gatekeeper prompt), formulae don't. Migrate later if needed.