### PR TITLE
docs: per-OS install (macOS brew, Linux curl, go); changelog v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- docs: document Homebrew as the recommended macOS install — `brew install seibert-data/tap/teamvault-cli` (and `brew upgrade` for updates) via the published cask; `go install` kept as the cross-platform alternative.
+
+## v5.4.0
+
 - feat(cli): add `--version` — `teamvault-cli --version` prints the release. Injected at build time via `-ldflags` (`make install`), with a `debug.ReadBuildInfo` fallback so `go install …/v5@vX.Y.Z` also reports the real module version.
 
 ## v5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- docs: document Homebrew as the recommended macOS install — `brew install seibert-data/tap/teamvault-cli` (and `brew upgrade` for updates) via the published cask; `go install` kept as the cross-platform alternative.
+- docs: add per-OS install instructions across the README, the getting-started guide, and the Claude Code skill — Homebrew for macOS (`brew install seibert-data/tap/teamvault-cli`), a prebuilt-binary `curl` one-liner for Linux (no Go toolchain needed), and `go install` as the any-platform fallback.
 
 ## v5.4.0
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ brew install seibert-data/tap/teamvault-cli
 
 Update later with `brew upgrade teamvault-cli`. The cask installs an unsigned binary and strips the download quarantine, so it runs without a Gatekeeper prompt.
 
+**Linux** — prebuilt release binary (no Go toolchain needed):
+
+```bash
+curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/download/teamvault-cli_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz teamvault-cli && sudo install teamvault-cli /usr/local/bin/ && rm teamvault-cli
+```
+
+Re-run to update. Covers both `x86_64` and `arm64`/`aarch64`.
+
 **Any platform** — via Go:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -9,11 +9,23 @@ Read secrets from [TeamVault](https://github.com/trustedsec/teamvault) — passw
 
 ## Install the CLI
 
+**macOS (recommended)** — via [Homebrew](https://brew.sh):
+
+```bash
+brew install seibert-data/tap/teamvault-cli
+```
+
+Update later with `brew upgrade teamvault-cli`. The cask installs an unsigned binary and strips the download quarantine, so it runs without a Gatekeeper prompt.
+
+**Any platform** — via Go:
+
 ```bash
 go install github.com/Seibert-Data/teamvault-cli/v5@latest
 ```
 
-Installs a `teamvault-cli` binary into `$(go env GOPATH)/bin`. Check it: `teamvault-cli --help`.
+Installs a `teamvault-cli` binary into `$(go env GOPATH)/bin`.
+
+Check either install: `teamvault-cli --version`.
 
 ## Install the Claude Code plugin
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,14 +6,36 @@ One binary, a handful of subcommands, and your secret never has to sit in plaint
 
 ## 1. Install
 
+Pick the one for your OS. Each drops a single `teamvault-cli` binary on your `PATH`.
+
+**macOS — [Homebrew](https://brew.sh) (recommended):**
+
+```bash
+brew install seibert-data/tap/teamvault-cli
+```
+
+Update later with `brew upgrade teamvault-cli`. The cask installs an unsigned binary and strips the download quarantine, so it runs without a Gatekeeper prompt.
+
+**Linux — prebuilt release binary (no Go toolchain needed):**
+
+```bash
+curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/download/teamvault-cli_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz teamvault-cli && sudo install teamvault-cli /usr/local/bin/ && rm teamvault-cli
+```
+
+To update, re-run the command. (`x86_64` and `arm64`/`aarch64` are both covered.)
+
+**Any platform — Go toolchain:**
+
 ```bash
 go install github.com/Seibert-Data/teamvault-cli/v5@latest
 ```
 
-This puts a single `teamvault-cli` binary on your `PATH` (in `$(go env GOPATH)/bin`). Verify:
+Puts the binary in `$(go env GOPATH)/bin`.
+
+Verify whichever you picked:
 
 ```bash
-teamvault-cli --help
+teamvault-cli --version
 ```
 
 ## 2. Configure

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -11,7 +11,21 @@ Full walkthrough for humans: `docs/getting-started.md` in the teamvault-cli repo
 
 ## Prerequisites (check first, set up if missing)
 
-Run `teamvault-cli --help`. If the command is missing:
+Run `teamvault-cli --help`. If the command is missing, install it — pick by the user's platform:
+
+**macOS** (Homebrew):
+
+```bash
+brew install seibert-data/tap/teamvault-cli
+```
+
+**Linux** (prebuilt release binary — no Go toolchain needed):
+
+```bash
+curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/download/teamvault-cli_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz teamvault-cli && sudo install teamvault-cli /usr/local/bin/ && rm teamvault-cli
+```
+
+**Any platform with Go**:
 
 ```bash
 go install github.com/Seibert-Data/teamvault-cli/v5@latest   # installs to $(go env GOPATH)/bin


### PR DESCRIPTION
## What

Per-OS install docs so both macOS and Linux users have a first-class path in v1 — applied consistently across the README, the getting-started guide, and the Claude Code skill:

- **macOS** — `brew install seibert-data/tap/teamvault-cli` (+ `brew upgrade`) via the published cask (recommended).
- **Linux** — prebuilt-binary `curl` one-liner from the GitHub release (no Go toolchain needed); `uname -m` covers `x86_64` + `arm64`/`aarch64`.
- **Any platform** — `go install …/v5@latest` fallback.

Also: **CHANGELOG** `## Unreleased` → `## v5.4.0` (the `--version` feature; v5.4.0 is already tagged + released, cask live on the tap), plus a fresh `## Unreleased` for these install docs.

## Why

The Homebrew tap has published the cask since v5.4.0 but nothing documented it, and there was no non-Go install path for Linux at all. This gives every supported user a copy-paste install + update one-liner.

## Verification

- `make precommit` green (143 specs, 0 lint, 0 vuln).
- `brew install seibert-data/tap/teamvault-cli` verified E2E on macOS → `teamvault-cli --version` → v5.4.0, no Gatekeeper prompt.
- Linux tarball layout confirmed (`teamvault-cli` binary at archive root; `tar xz teamvault-cli` extracts it).