### PR TITLE
chore(dark-factory): reconcile stale spec 005 bookkeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverprofile.out
 /.update-logs/
 /.dark-factory.lock
 /.dark-factory.log
+/.dark-factory/
 /prompts/log
 /specs/log
 /teamvault-config-dir-generator

--- a/prompts/cancelled/012-spec-005-login-config-and-cmd-removal.md
+++ b/prompts/cancelled/012-spec-005-login-config-and-cmd-removal.md
@@ -1,8 +1,9 @@
 ---
-status: approved
+status: cancelled
 spec: [005-consolidate-cli-into-teamvault-command]
 created: "2026-07-09T15:01:03Z"
 queued: "2026-07-09T15:16:04Z"
+cancelled: "2026-07-11T12:44:19Z"
 ---
 
 <summary>

--- a/prompts/cancelled/013-spec-005-scenarios-docs-changelog.md
+++ b/prompts/cancelled/013-spec-005-scenarios-docs-changelog.md
@@ -1,8 +1,9 @@
 ---
-status: approved
+status: cancelled
 spec: [005-consolidate-cli-into-teamvault-command]
 created: "2026-07-09T15:01:03Z"
 queued: "2026-07-09T15:16:04Z"
+cancelled: "2026-07-11T12:44:19Z"
 ---
 
 <summary>

--- a/specs/completed/005-consolidate-cli-into-teamvault-command.md
+++ b/specs/completed/005-consolidate-cli-into-teamvault-command.md
@@ -1,8 +1,10 @@
 ---
-status: prompted
+status: completed
 approved: "2026-07-09T14:31:51Z"
 generating: "2026-07-09T15:15:36Z"
 prompted: "2026-07-09T15:15:36Z"
+verifying: "2026-07-11T12:45:37Z"
+completed: "2026-07-11T12:45:51Z"
 branch: dark-factory/consolidate-cli-into-teamvault-command
 issue: IT-44264
 ---


### PR DESCRIPTION
## What

Spec 005 (the v5 CLI consolidation) shipped its code in v5.x, but its prompts **012** and **013** were left in the queue as `approved` — the spec sat at `prompted 2/4` indefinitely.

- **Cancel prompts 012 + 013** (`prompts/in-progress/` → `prompts/cancelled/`). Their work is already in master: `cmd/` binaries removed, `pkg/cli/{login,config}.go` present, `scenarios/001–005` + v5 CHANGELOG shipped. Re-running them is moot.
- **Mark spec 005 completed** (`specs/in-progress/` → `specs/completed/`).
- **Gitignore `/.dark-factory/`** — the local `doctor.log` audit dir.

## Why

A stale `prompted` spec with un-run `approved` prompts is a landmine: the moment a `dark-factory daemon`/`run` starts in this repo, it picks up those queued prompts and — under `workflow: direct` — commits them to whatever branch is checked out. This reconciles the bookkeeping to match what actually shipped, so the repo is clean for future dark-factory sessions.

Pipeline-metadata only — no product code, no CHANGELOG/version impact.