### PR TITLE
feat(config): XDG-first config default with legacy ~/.teamvault.json fallback

### DIFF
--- a/.dark-factory.yaml
+++ b/.dark-factory.yaml
@@ -1,3 +1,4 @@
+autoGeneratePrompts: true
 autoRelease: false
 maxContainers: 8
 pr: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- feat(config): default the config location when neither `--teamvault-config` nor `TEAMVAULT_CONFIG` is set — read the XDG path `~/.config/teamvault-cli/config.json` (honors `$XDG_CONFIG_HOME`) if present, else the legacy `~/.teamvault.json`. No config was read by default before; explicit flag/env still override, and an absent file keeps prior behaviour. Aligns with the XDG Base Directory convention used across the toolchain.
 - docs: add per-OS install instructions across the README, the getting-started guide, and the Claude Code skill — Homebrew for macOS (`brew install seibert-data/tap/teamvault-cli`), a prebuilt-binary `curl` one-liner for Linux (no Go toolchain needed), and `go install` as the any-platform fallback.
 
 ## v5.4.0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ Then use `/teamvault` in Claude Code to fetch a secret or set up the CLI.
 
 ## Configure
 
-`teamvault-cli` reads its server URL and username from `~/.teamvault.json`. Leave the password **out** of the file — store it in the macOS Keychain instead.
+`teamvault-cli` reads its server URL and username from a JSON config file. By default it looks in two places, in order — the XDG path first, then the legacy home-root path:
+
+1. `~/.config/teamvault-cli/config.json` (XDG — recommended)
+2. `~/.teamvault.json` (legacy fallback)
+
+Point it elsewhere with `--teamvault-config <path>` or `TEAMVAULT_CONFIG`. Leave the password **out** of the file — store it in the macOS Keychain instead.
 
 ```json
 { "url": "https://teamvault.your-company.example", "user": "your-username" }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,10 @@ teamvault-cli --version
 
 `teamvault-cli` needs to know your TeamVault URL and username. The password is best left out of the config file and stored in your macOS Keychain via `teamvault-cli login` (see step 3).
 
-Create `~/.teamvault.json`:
+Create the config file. With no flag or env var set, the tool reads the first that exists, XDG path first:
+
+1. `~/.config/teamvault-cli/config.json` (XDG — recommended; honors `$XDG_CONFIG_HOME`)
+2. `~/.teamvault.json` (legacy fallback — still works)
 
 ```json
 {
@@ -51,7 +54,7 @@ Create `~/.teamvault.json`:
 }
 ```
 
-Point the tool at it with `--teamvault-config ~/.teamvault.json`, or export `TEAMVAULT_CONFIG=~/.teamvault.json` once (e.g. in your shell profile or a project `.envrc`).
+To use a different location, pass `--teamvault-config <path>` or export `TEAMVAULT_CONFIG=<path>` once (e.g. in your shell profile or a project `.envrc`) — both override the default lookup.
 
 Every setting also has a flag and an environment variable, so you can skip the config file entirely if you prefer:
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
 	"syscall"
 
@@ -39,6 +40,41 @@ func resolveVersion() string {
 		}
 	}
 	return version
+}
+
+// legacyConfigPath is the historical home-root config location. Kept in tilde
+// form so TeamvaultConfigPath.NormalizePath expands it at use time.
+const legacyConfigPath = "~/.teamvault.json"
+
+// resolveDefaultConfigPath decides which config file the CLI reads when no
+// --teamvault-config flag is given. Precedence: the TEAMVAULT_CONFIG env var,
+// then the XDG path (~/.config/teamvault-cli/config.json) when that file
+// exists, then the legacy ~/.teamvault.json. The returned path is still passed
+// through TeamvaultConfigPath.Exists/NormalizePath, so an absent legacy file
+// leaves behaviour unchanged (no config read).
+func resolveDefaultConfigPath() string {
+	if env := os.Getenv("TEAMVAULT_CONFIG"); env != "" {
+		return env
+	}
+	if xdg := xdgConfigPath(); xdg != "" && teamvault.TeamvaultConfigPath(xdg).Exists() {
+		return xdg
+	}
+	return legacyConfigPath
+}
+
+// xdgConfigPath returns the XDG Base Directory config location
+// (${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli/config.json), or "" when
+// neither XDG_CONFIG_HOME nor a home directory can be determined.
+func xdgConfigPath() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "teamvault-cli", "config.json")
 }
 
 // Execute runs the CLI application. It sets up signal handling for SIGINT and
@@ -104,8 +140,8 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	pf.StringVar(
 		&sf.configPath,
 		"teamvault-config",
-		os.Getenv("TEAMVAULT_CONFIG"),
-		"teamvault config file path",
+		resolveDefaultConfigPath(),
+		"teamvault config file path (default: $TEAMVAULT_CONFIG, else ~/.config/teamvault-cli/config.json, else ~/.teamvault.json)",
 	)
 	pf.BoolVar(&sf.staging, "staging", envBool("STAGING"), "staging status")
 	pf.BoolVar(&sf.cache, "cache", envBool("CACHE"), "enable teamvault secret cache")

--- a/pkg/cli/config_path_resolver_test.go
+++ b/pkg/cli/config_path_resolver_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// saveEnv snapshots the given env vars and restores them after the spec.
+func saveEnv(keys ...string) {
+	saved := make(map[string]string, len(keys))
+	for _, k := range keys {
+		saved[k] = os.Getenv(k)
+	}
+	DeferCleanup(func() {
+		for k, v := range saved {
+			if v == "" {
+				Expect(os.Unsetenv(k)).To(Succeed())
+			} else {
+				Expect(os.Setenv(k, v)).To(Succeed())
+			}
+		}
+	})
+}
+
+var _ = Describe("resolveDefaultConfigPath", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		tmpDir = GinkgoT().TempDir()
+		saveEnv("TEAMVAULT_CONFIG", "XDG_CONFIG_HOME", "HOME")
+		Expect(os.Setenv("XDG_CONFIG_HOME", tmpDir)).To(Succeed())
+	})
+
+	It("returns TEAMVAULT_CONFIG when set, ignoring the candidates", func() {
+		Expect(os.Setenv("TEAMVAULT_CONFIG", "/explicit/config.json")).To(Succeed())
+		Expect(resolveDefaultConfigPath()).To(Equal("/explicit/config.json"))
+	})
+
+	It("returns the XDG path when its config exists and env is empty", func() {
+		Expect(os.Unsetenv("TEAMVAULT_CONFIG")).To(Succeed())
+		xdg := filepath.Join(tmpDir, "teamvault-cli", "config.json")
+		Expect(os.MkdirAll(filepath.Dir(xdg), 0o700)).To(Succeed())
+		Expect(os.WriteFile(xdg, []byte(`{"url":"x","user":"y"}`), 0o600)).To(Succeed())
+		Expect(resolveDefaultConfigPath()).To(Equal(xdg))
+	})
+
+	It("falls back to the legacy path when the XDG config is absent", func() {
+		Expect(os.Unsetenv("TEAMVAULT_CONFIG")).To(Succeed())
+		// XDG_CONFIG_HOME points at tmpDir but no teamvault-cli/config.json exists.
+		Expect(resolveDefaultConfigPath()).To(Equal(legacyConfigPath))
+	})
+})
+
+var _ = Describe("xdgConfigPath", func() {
+	BeforeEach(func() {
+		saveEnv("XDG_CONFIG_HOME", "HOME")
+	})
+
+	It("uses XDG_CONFIG_HOME when set", func() {
+		Expect(os.Setenv("XDG_CONFIG_HOME", "/custom/xdg")).To(Succeed())
+		Expect(
+			xdgConfigPath(),
+		).To(Equal(filepath.Join("/custom/xdg", "teamvault-cli", "config.json")))
+	})
+
+	It("defaults to $HOME/.config when XDG_CONFIG_HOME is empty", func() {
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+		Expect(os.Setenv("HOME", "/home/tester")).To(Succeed())
+		Expect(
+			xdgConfigPath(),
+		).To(Equal(filepath.Join("/home/tester", ".config", "teamvault-cli", "config.json")))
+	})
+})

--- a/scenarios/006-config-path-resolution.md
+++ b/scenarios/006-config-path-resolution.md
@@ -1,0 +1,37 @@
+---
+status: active
+---
+
+# Scenario 006: config-path resolution (XDG-first, legacy fallback, overrides)
+
+Validates that the shipped `teamvault-cli` binary resolves its config file by the documented precedence — explicit flag → `TEAMVAULT_CONFIG` env → XDG (`$XDG_CONFIG_HOME/teamvault-cli/config.json`) → legacy (`~/.teamvault.json`) — and that an absent config is not silently replaced by a default read.
+
+Assumes a working legacy `~/.teamvault.json` (url + user, no `pass`) with the password already in the macOS Keychain via `teamvault-cli login`. Probe key `lO4K1w` (personal vault, username "longhorn"). Override via `TV_PROBE_KEY`. Uses a **temp** `XDG_CONFIG_HOME` so the real `~/.config` is never touched.
+
+## Setup
+
+- [ ] `go build -C ~/Documents/workspaces/sm-teamvault-cli-defaultconfig -o /tmp/teamvault-cli .`
+- [ ] `TV_KEY=${TV_PROBE_KEY:-lO4K1w}`
+- [ ] `[ -f ~/.teamvault.json ]` (legacy config exists)
+- [ ] `TV_XDG=$(mktemp -d)` (temp XDG root)
+- [ ] `mkdir -p "$TV_XDG/teamvault-cli" && cp ~/.teamvault.json "$TV_XDG/teamvault-cli/config.json"` (XDG config = copy of legacy)
+
+## Action
+
+- [ ] `LEGACY_OUT=$(env -u TEAMVAULT_CONFIG XDG_CONFIG_HOME=/tmp/tv-empty-xdg /tmp/teamvault-cli username --teamvault-key $TV_KEY 2>/tmp/s006-legacy.err); LEGACY_RC=$?` (no XDG file present → legacy fallback)
+- [ ] `XDG_OUT=$(env -u TEAMVAULT_CONFIG XDG_CONFIG_HOME="$TV_XDG" /tmp/teamvault-cli username --teamvault-key $TV_KEY 2>/tmp/s006-xdg.err); XDG_RC=$?` (XDG file present → XDG wins)
+- [ ] `FLAG_OUT=$(XDG_CONFIG_HOME=/tmp/tv-empty-xdg TEAMVAULT_CONFIG=/nonexistent-env.json /tmp/teamvault-cli username --teamvault-config ~/.teamvault.json --teamvault-key $TV_KEY 2>/tmp/s006-flag.err); FLAG_RC=$?` (flag beats env + XDG + legacy)
+- [ ] `BADENV_OUT=$(env -u XDG_CONFIG_HOME TEAMVAULT_CONFIG=/definitely/nonexistent.json /tmp/teamvault-cli username --teamvault-key $TV_KEY 2>/tmp/s006-badenv.err); BADENV_RC=$?` (env points at a missing file → NOT silently replaced by a default read)
+
+## Expected
+
+- [ ] `[ "$LEGACY_RC" = "0" ] && [ "$LEGACY_OUT" = "longhorn" ]` (legacy `~/.teamvault.json` read when no XDG file)
+- [ ] `[ "$XDG_RC" = "0" ] && [ "$XDG_OUT" = "longhorn" ]` (XDG `config.json` read when present)
+- [ ] `[ "$FLAG_RC" = "0" ] && [ "$FLAG_OUT" = "longhorn" ]` (explicit `--teamvault-config` wins over env + XDG)
+- [ ] `[ "$BADENV_RC" != "0" ]` (a `TEAMVAULT_CONFIG` pointing at a missing file does NOT fall back to the default — the env value is authoritative; command fails for lack of url/user)
+
+## Cleanup
+
+```bash
+rm -rf "$TV_XDG" /tmp/teamvault-cli /tmp/s006-*.err
+```

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -31,13 +31,13 @@ curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/downloa
 go install github.com/Seibert-Data/teamvault-cli/v5@latest   # installs to $(go env GOPATH)/bin
 ```
 
-Config: `teamvault-cli` needs a URL + username. Check for `~/.teamvault.json`:
+Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy). Check for either:
 
 ```json
 { "url": "https://teamvault.your-company.example", "user": "your-teamvault-username" }
 ```
 
-Point at it with `--teamvault-config ~/.teamvault.json` or `export TEAMVAULT_CONFIG=~/.teamvault.json`. Every setting also has a flag (`--teamvault-url`, `--teamvault-user`, …) and env var (`TEAMVAULT_URL`, `TEAMVAULT_USER`, …); precedence is flag → env → config file.
+Override the location with `--teamvault-config <path>` or `export TEAMVAULT_CONFIG=<path>`. Every setting also has a flag (`--teamvault-url`, `--teamvault-user`, …) and env var (`TEAMVAULT_URL`, `TEAMVAULT_USER`, …); precedence is flag → env → config file.
 
 Password: prefer the Keychain over the config file. Run `teamvault-cli login` once — it verifies the password and stores it in the macOS Keychain, after which every command reads it automatically.
 

--- a/specs/completed/006-default-teamvault-config-path.md
+++ b/specs/completed/006-default-teamvault-config-path.md
@@ -1,0 +1,94 @@
+---
+status: completed
+branch: feature/default-config-path
+issue: IT-44264
+note: "Design record — hand-authored (route B), not executed via dark-factory containers. Supersedes the rejected prompted draft of the same number."
+---
+
+## Summary
+
+- Default the config file location when neither `--teamvault-config` nor `TEAMVAULT_CONFIG` is set, checking **two candidates in order**: XDG `${XDG_CONFIG_HOME:-~/.config}/teamvault-cli/config.json`, then legacy `~/.teamvault.json`.
+- Adopts the **XDG Base Directory** pattern already shipped across the sibling tools (dark-factory, vault-cli, task-watcher, vault-ui, claude-code-router): **XDG-first, legacy-fallback**, no env var or flag required.
+- v5 is a breaking major release — the right moment to make the XDG path primary.
+- Backward compatible: an existing `~/.teamvault.json` keeps working (fallback); `--teamvault-config` and `TEAMVAULT_CONFIG` still override; JSON format unchanged.
+
+## Problem
+
+`teamvault-cli` applies **no built-in default config path** (`pkg/cli/cli.go` seeds the `--teamvault-config` flag default from `os.Getenv("TEAMVAULT_CONFIG")`, which is empty when unset → `Exists()` false → no config file read). Users must set `TEAMVAULT_CONFIG` or pass the flag every time. Verified this was never a code default in any version (v4.12.0 struct tag carries no `default:`; `git log --all -S'teamvault.json' -- '*.go'` is empty back to tag 1.1.0) — so a default is a new `feat`, not a regression.
+
+Separately, the tool's config lives at home-root (`~/.teamvault.json`) while the rest of the toolchain has migrated to `~/.config/<tool>/` (XDG). teamvault-cli is the last holdout; aligning it removes home-dir clutter and makes the config discoverable where users now look.
+
+## Goal
+
+When the config path is not explicitly provided (flag absent AND `TEAMVAULT_CONFIG` empty), resolve it to the **first existing** of: the XDG path `${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli/config.json`, then the legacy `~/.teamvault.json`. If neither exists, no config file is read (unchanged `Exists()` behaviour). Explicit `--teamvault-config` and `TEAMVAULT_CONFIG` keep precedence; field-level precedence (flag/env beats config-file values) is untouched; format stays JSON.
+
+## Non-goals
+
+- A company-specific env var (`TEAMVAULT_SEIBERT`, `TEAMVAULT_SM`) — `TEAMVAULT_CONFIG` already overrides the location.
+- Auto-migrating or auto-creating either config file. Absent stays absent (no write).
+- Candidate paths beyond these two (no `./.teamvault.json`, no `/etc/...`, no other XDG dirs).
+- XDG-compliant **cache/data** dirs — only `~/.config` scope (matches the XDG goal's scope).
+- Changing the config file format — JSON stays JSON.
+- Field-level precedence changes.
+
+## Desired Behavior
+
+Config-path resolution (location only — field precedence unchanged). XDG path = `${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli/config.json`.
+
+| `--teamvault-config` | `TEAMVAULT_CONFIG` | XDG file exists | Resolved config path |
+|---|---|---|---|
+| set | (any) | (any) | the flag value |
+| unset | non-empty | (any) | the env value |
+| unset | empty | yes | XDG path |
+| unset | empty | no | legacy `~/.teamvault.json` |
+
+1. The resolved path passes through the existing `TeamvaultConfigPath.NormalizePath()` (`~` expansion).
+2. The file is read only when `Exists()` is true. If neither XDG nor legacy exists, nothing is read — identical to today.
+3. Applies to every subcommand via the shared persistent flag (`password`, `username`, `url`, `file`, `config parse`, `config generate`, `login`).
+4. Explicit `--teamvault-url`/`TEAMVAULT_URL` (etc.) still override config-file values — the default only decides *which file* is read.
+
+## Constraints
+
+- Resolver is a small, unit-testable helper: given the `TEAMVAULT_CONFIG` env value, return it when non-empty; else return the XDG path if that file exists; else the legacy path. It performs a filesystem existence check on the XDG candidate — testable by injecting temp `HOME` + `XDG_CONFIG_HOME`.
+- Respect `XDG_CONFIG_HOME` (default `$HOME/.config` when unset) — proper XDG behaviour.
+- XDG directory name is `teamvault-cli` (matches the sibling `~/.config/vault-cli/` convention), file `config.json`.
+- Default strings stay in tilde/`$HOME`-relative form until `NormalizePath` expands them at use time — no pre-expanded absolute paths baked into the flag default.
+- No new external dependencies. Public Go API stays source-compatible (CLI-layer change in `pkg/cli`).
+- Errors wrapped via `github.com/bborbe/errors`; no `fmt.Errorf`. Exported items have GoDoc per `docs/dod.md`. Tests use Ginkgo/Gomega.
+
+## Failure Modes
+
+| Trigger | Expected behavior | Recovery |
+|---|---|---|
+| Neither XDG nor legacy present, no flag/env | No config read; url/user/pass from flags/env/Keychain as today | None — unchanged |
+| XDG present but malformed JSON | Same wrapped parse error as a malformed explicit config | Fix the file, or point elsewhere via `TEAMVAULT_CONFIG` |
+| XDG absent, legacy present | Legacy `~/.teamvault.json` is read (fallback) | None — intended |
+| Both present | XDG wins (first candidate); legacy ignored | Remove/relocate XDG, or set `TEAMVAULT_CONFIG` |
+| `XDG_CONFIG_HOME` set to a custom dir | XDG candidate resolves under it | — |
+| `HOME` and `XDG_CONFIG_HOME` both unset (rare CI) | Both candidates fail to resolve → `Exists()` false → no config read | Provide flags/env, or set `TEAMVAULT_CONFIG` |
+
+## Acceptance Criteria
+
+- [ ] Resolver (`pkg/cli`): env non-empty → env value; env empty + XDG file exists → XDG path; env empty + XDG absent → legacy `~/.teamvault.json`. Respects `XDG_CONFIG_HOME` (default `$HOME/.config`), dir `teamvault-cli`, file `config.json`.
+- [ ] Explicit `--teamvault-config <path>` overrides env, XDG, and legacy (cobra flag precedence).
+- [ ] Default applies across subcommands via the shared persistent flag (verified for `password` + `login`).
+- [ ] Backward compatible: legacy `~/.teamvault.json` is read when XDG is absent; when neither exists, no config read (the `Exists()`-false branch).
+- [ ] Unit tests (Ginkgo/Gomega) inject temp `HOME`/`XDG_CONFIG_HOME` and cover all four resolution-table rows + the `Exists()`-false fallthrough.
+- [ ] Scenario `scenarios/006-config-path-resolution.md` (`status: active`) validates the shipped binary: XDG-present, XDG-absent-legacy-present, both-absent (no silent default read), env-override, flag-beats-env — keyed on probe `lO4K1w` → `longhorn`.
+- [ ] `make precommit` exits 0.
+- [ ] Docs updated (README, `docs/getting-started.md`, `skills/teamvault/SKILL.md`): XDG `~/.config/teamvault-cli/config.json` is the primary default, `~/.teamvault.json` the fallback, `TEAMVAULT_CONFIG` overrides both.
+- [ ] `CHANGELOG.md` `## Unreleased` `feat` entry describing the XDG-first + legacy-fallback default.
+
+## Verification
+
+- `make precommit` → exit 0.
+- XDG-present: with `~/.config/teamvault-cli/config.json` valid, no env/flag → `teamvault-cli --staging username --teamvault-key lO4K1w` reads it.
+- Fallback: remove the XDG file, keep `~/.teamvault.json` → same command still resolves (legacy read).
+- Override: `TEAMVAULT_CONFIG=/tmp/other.json` and `--teamvault-config /tmp/other.json` each win over the defaults.
+- Custom XDG: `XDG_CONFIG_HOME=/tmp/xdg` with `/tmp/xdg/teamvault-cli/config.json` present → read.
+
+## Notes
+
+- Hand-authored (route B) after the dark-factory container path hit repeated friction on this small change (stale spec-005 auto-run, reviewer-bot malfunction, lifecycle tangles). This spec is the design/why record; the code + tests + scenario + docs ship in the same PR.
+- Implementation is CLI-layer only: replace the `os.Getenv("TEAMVAULT_CONFIG")` flag default in `pkg/cli/cli.go` with the resolver. `factory.go`/`login.go`/`config-path.go` are untouched — the `Exists()` gate gives "absent file → no-op" for free.
+- Aligns with `[[Migrate Configs to XDG Base Directory]]` (XDG-first, legacy-fallback across the toolchain).


### PR DESCRIPTION
## What

Give `teamvault-cli` a built-in default config location (it had none — an unset `TEAMVAULT_CONFIG` meant *no* config file was read). With no `--teamvault-config` flag and no `TEAMVAULT_CONFIG` env, resolve to the first that exists:

1. `~/.config/teamvault-cli/config.json` (XDG — honors `$XDG_CONFIG_HOME`)
2. `~/.teamvault.json` (legacy fallback)

Full precedence: **flag → env → XDG → legacy**. Absent files → no read (unchanged behaviour). Format stays JSON.

## Why

- Adopts the **XDG Base Directory** pattern already shipped across the sibling tools (dark-factory, vault-cli, task-watcher, vault-ui, claude-code-router) — teamvault-cli was the holdout. v5 is a breaking major, the right moment to make XDG primary.
- Removes the papercut where dropping a config in the obvious place did nothing until you also exported an env var. Zero-config for the common case; the legacy `~/.teamvault.json` keeps working.

## Changes

- `pkg/cli/cli.go`: `resolveDefaultConfigPath()` + `xdgConfigPath()` seed the `--teamvault-config` flag default (was `os.Getenv("TEAMVAULT_CONFIG")`). CLI-layer only; `factory`/`config-path` untouched (the `Exists()` gate gives absent-file → no-op for free).
- Ginkgo tests (`config_path_resolver_test.go`): all four resolution-table rows + `XDG_CONFIG_HOME` handling, via injected temp `HOME`/`XDG_CONFIG_HOME`.
- Scenario `scenarios/006-config-path-resolution.md`: shipped-binary walk (XDG-present / legacy-fallback / flag-beats-env / bad-env-not-silently-defaulted), temp `XDG_CONFIG_HOME` so it never touches real `~/.config`.
- Docs (README, getting-started, SKILL) + CHANGELOG `feat`.
- Design record: `specs/completed/006-default-teamvault-config-path.md`.

## Verification

- `make precommit` green (148 specs, 0 lint, 0 vuln).
- Smoke: real binary `--help` documents the precedence; with no `~/.config/teamvault-cli/config.json` present it correctly falls back to `~/.teamvault.json`; temp-`XDG_CONFIG_HOME` staging run exits 0.
- Live scenario 006 (real fetch proving XDG vs legacy) is the manual verify step — needs a real key + Keychain.