### PR TITLE
test(config): cover nil-HOME edge case

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -62,13 +62,19 @@ func resolveDefaultConfigPath() string {
 	return legacyConfigPath
 }
 
+// userHomeDir is a seam over os.UserHomeDir so tests can simulate a missing
+// home directory deterministically — os.UserHomeDir's getpwuid_r fallback (cgo)
+// can return a home from /etc/passwd even with $HOME unset, making env-only
+// tests platform-dependent.
+var userHomeDir = os.UserHomeDir
+
 // xdgConfigPath returns the XDG Base Directory config location
 // (${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli/config.json), or "" when
 // neither XDG_CONFIG_HOME nor a home directory can be determined.
 func xdgConfigPath() string {
 	base := os.Getenv("XDG_CONFIG_HOME")
 	if base == "" {
-		home, err := os.UserHomeDir()
+		home, err := userHomeDir()
 		if err != nil || home == "" {
 			return ""
 		}

--- a/pkg/cli/config_path_resolver_test.go
+++ b/pkg/cli/config_path_resolver_test.go
@@ -56,6 +56,13 @@ var _ = Describe("resolveDefaultConfigPath", func() {
 		// XDG_CONFIG_HOME points at tmpDir but no teamvault-cli/config.json exists.
 		Expect(resolveDefaultConfigPath()).To(Equal(legacyConfigPath))
 	})
+
+	It("falls back to the legacy path when HOME and XDG_CONFIG_HOME are both unset", func() {
+		Expect(os.Unsetenv("TEAMVAULT_CONFIG")).To(Succeed())
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+		Expect(os.Unsetenv("HOME")).To(Succeed())
+		Expect(resolveDefaultConfigPath()).To(Equal(legacyConfigPath))
+	})
 })
 
 var _ = Describe("xdgConfigPath", func() {
@@ -76,5 +83,11 @@ var _ = Describe("xdgConfigPath", func() {
 		Expect(
 			xdgConfigPath(),
 		).To(Equal(filepath.Join("/home/tester", ".config", "teamvault-cli", "config.json")))
+	})
+
+	It("returns empty when both XDG_CONFIG_HOME and HOME are unset", func() {
+		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+		Expect(os.Unsetenv("HOME")).To(Succeed())
+		Expect(xdgConfigPath()).To(Equal(""))
 	})
 })

--- a/pkg/cli/config_path_resolver_test.go
+++ b/pkg/cli/config_path_resolver_test.go
@@ -5,12 +5,22 @@
 package cli
 
 import (
+	stderrors "errors"
 	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// stubNoHome makes userHomeDir report failure for the duration of the spec, so
+// the "no home directory" branch is exercised deterministically regardless of
+// the platform's os.UserHomeDir getpwuid_r fallback.
+func stubNoHome() {
+	orig := userHomeDir
+	userHomeDir = func() (string, error) { return "", stderrors.New("no home") }
+	DeferCleanup(func() { userHomeDir = orig })
+}
 
 // saveEnv snapshots the given env vars and restores them after the spec.
 func saveEnv(keys ...string) {
@@ -57,10 +67,10 @@ var _ = Describe("resolveDefaultConfigPath", func() {
 		Expect(resolveDefaultConfigPath()).To(Equal(legacyConfigPath))
 	})
 
-	It("falls back to the legacy path when HOME and XDG_CONFIG_HOME are both unset", func() {
+	It("falls back to the legacy path when the home directory cannot be determined", func() {
 		Expect(os.Unsetenv("TEAMVAULT_CONFIG")).To(Succeed())
 		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
-		Expect(os.Unsetenv("HOME")).To(Succeed())
+		stubNoHome()
 		Expect(resolveDefaultConfigPath()).To(Equal(legacyConfigPath))
 	})
 })
@@ -85,9 +95,12 @@ var _ = Describe("xdgConfigPath", func() {
 		).To(Equal(filepath.Join("/home/tester", ".config", "teamvault-cli", "config.json")))
 	})
 
-	It("returns empty when both XDG_CONFIG_HOME and HOME are unset", func() {
-		Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
-		Expect(os.Unsetenv("HOME")).To(Succeed())
-		Expect(xdgConfigPath()).To(Equal(""))
-	})
+	It(
+		"returns empty when XDG_CONFIG_HOME is unset and the home directory cannot be determined",
+		func() {
+			Expect(os.Unsetenv("XDG_CONFIG_HOME")).To(Succeed())
+			stubNoHome()
+			Expect(xdgConfigPath()).To(Equal(""))
+		},
+	)
 })


### PR DESCRIPTION
Addresses the Nice-to-Have coverage nit from the #23 review: adds tests for the boundary where both `XDG_CONFIG_HOME` and `HOME` are unset.

- `xdgConfigPath()` returns `""`.
- `resolveDefaultConfigPath()` falls through to the legacy `~/.teamvault.json` (no config read downstream, unchanged behaviour).

Test-only; `make precommit` green (150 specs).

(Also serves as the master-SHA bump that re-triggers the now-fixed auto-release for this repo.)