### PR TITLE
test(e2e): fakevault server + hermetic CI-runnable scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,25 @@ jobs:
         with:
           fail_ci_if_error: false
 
+  # Hermetic end-to-end test: start the fake TeamVault server (cmd/fakevault)
+  # and drive the real teamvault-cli binary against it — no live TeamVault, no
+  # Keychain. Exercises the real HTTP connector + auth + parse path.
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run e2e
+        run: make e2e
+
   # Validate the release pipeline on every PR so a broken .goreleaser.yaml
   # surfaces here, not only at tag-push. `build` skips the publish/brew steps,
   # so no tokens are needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- test(e2e): add `cmd/fakevault` — a fake TeamVault HTTP server with seeded secrets — plus a `make e2e` target, scenario 007, and a CI job that drives the real `teamvault-cli` binary against it (temp config + `TEAMVAULT_PASS`, no live TeamVault / Keychain). Exercises the real HTTP connector, Basic-auth, and JSON-parse path that `--staging` and unit tests do not; makes the read scenarios hermetic and CI-runnable. `fakevault` is a test helper and is not shipped.
+
 ## v5.5.0
 
 - feat(config): default the config location when neither `--teamvault-config` nor `TEAMVAULT_CONFIG` is set — read the XDG path `~/.config/teamvault-cli/config.json` (honors `$XDG_CONFIG_HOME`) if present, else the legacy `~/.teamvault.json`. No config was read by default before; explicit flag/env still override, and an absent file keeps prior behaviour. Aligns with the XDG Base Directory convention used across the toolchain.

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ endif
 test:
 	go run github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION) -r --randomize-all $(TESTFLAGS_RACE) --cover --trace
 
+.PHONY: e2e
+e2e:
+	bash scripts/e2e.sh
+
 .PHONY: check
 check: lint vet vulncheck osv-scanner trivy
 

--- a/cmd/fakevault/main.go
+++ b/cmd/fakevault/main.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Command fakevault is a minimal fake TeamVault HTTP server for hermetic,
+// CI-runnable end-to-end tests of teamvault-cli. It implements only the four
+// read endpoints the remote connector calls (see pkg/remote-connector.go) and
+// serves a fixed set of in-memory secrets. It is a test helper and is never
+// shipped (goreleaser builds the root `main: .` only).
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// secret is one fixture entry served by the fake.
+type secret struct {
+	Username string
+	URL      string
+	Password string
+	File     string
+}
+
+// fixtures is the seeded secret set. Scenarios/e2e tests reference these keys
+// and assert the values below.
+var fixtures = map[string]secret{
+	"demo": {
+		Username: "demo-user",
+		URL:      "https://demo.example/login",
+		Password: "demo-pass-123",
+		File:     "demo-file-contents",
+	},
+	"AbC123": {
+		Username: "alice",
+		URL:      "https://api.internal",
+		Password: "s3cr3t-value",
+		File:     "certificate-bytes",
+	},
+}
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:0", "listen address (use :0 for an OS-assigned port)")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+
+	// GET /api/secrets/{key}/ — secret metadata (username, url, current_revision).
+	mux.HandleFunc("GET /api/secrets/{key}/", func(w http.ResponseWriter, r *http.Request) {
+		if !authOK(w, r) {
+			return
+		}
+		s, ok := fixtures[r.PathValue("key")]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"username": s.Username,
+			"url":      s.URL,
+			"current_revision": fmt.Sprintf(
+				"http://%s/api/secret-revisions/%s/",
+				r.Host,
+				r.PathValue("key"),
+			),
+		})
+	})
+
+	// GET /api/secret-revisions/{key}/data — revision data (password, file).
+	mux.HandleFunc(
+		"GET /api/secret-revisions/{key}/data",
+		func(w http.ResponseWriter, r *http.Request) {
+			if !authOK(w, r) {
+				return
+			}
+			s, ok := fixtures[r.PathValue("key")]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			writeJSON(w, map[string]any{"password": s.Password, "file": s.File})
+		},
+	)
+
+	// GET /api/secrets/?search=q — search (login probe). Matches on key or username.
+	mux.HandleFunc("GET /api/secrets/{$}", func(w http.ResponseWriter, r *http.Request) {
+		if !authOK(w, r) {
+			return
+		}
+		q := r.URL.Query().Get("search")
+		results := make([]map[string]string, 0, len(fixtures))
+		for key, s := range fixtures {
+			if q == "" || strings.Contains(key, q) || strings.Contains(s.Username, q) {
+				results = append(results, map[string]string{
+					"api_url": fmt.Sprintf("http://%s/api/secrets/%s/", r.Host, key),
+				})
+			}
+		}
+		writeJSON(w, map[string]any{"results": results})
+	})
+
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("fakevault: listen %s: %v", *addr, err)
+	}
+	fmt.Printf("fakevault listening on http://%s\n", ln.Addr())
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+	log.Fatal(srv.Serve(ln))
+}
+
+// authOK requires a Basic Authorization header (any credential) so tests prove
+// the CLI actually sends auth. It writes 401 and returns false when absent.
+func authOK(w http.ResponseWriter, r *http.Request) bool {
+	if _, _, ok := r.BasicAuth(); ok {
+		return true
+	}
+	w.Header().Set("WWW-Authenticate", `Basic realm="fakevault"`)
+	http.Error(w, "missing basic auth", http.StatusUnauthorized)
+	return false
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Printf("fakevault: encode: %v", err)
+	}
+}

--- a/cmd/fakevault/main.go
+++ b/cmd/fakevault/main.go
@@ -113,8 +113,8 @@ func main() {
 	srv := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       10 * time.Second,
-		WriteTimeout:      10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
 	}
 	log.Fatal(srv.Serve(ln))
 }

--- a/cmd/fakevault/main.go
+++ b/cmd/fakevault/main.go
@@ -45,8 +45,18 @@ var fixtures = map[string]secret{
 	},
 }
 
+// wantUser / wantPass are the Basic-auth credentials the server accepts (set
+// via flags). A request with any other credential gets 401 — so tests can
+// exercise the CLI's auth-failure path.
+var (
+	wantUser = "test"
+	wantPass = "test"
+)
+
 func main() {
 	addr := flag.String("addr", "127.0.0.1:0", "listen address (use :0 for an OS-assigned port)")
+	flag.StringVar(&wantUser, "user", "test", "required Basic-auth username")
+	flag.StringVar(&wantPass, "pass", "test", "required Basic-auth password")
 	flag.Parse()
 
 	mux := http.NewServeMux()
@@ -119,14 +129,15 @@ func main() {
 	log.Fatal(srv.Serve(ln))
 }
 
-// authOK requires a Basic Authorization header (any credential) so tests prove
-// the CLI actually sends auth. It writes 401 and returns false when absent.
+// authOK requires the configured Basic-auth credential so tests can exercise
+// both the happy path (correct creds) and the CLI's auth-failure path (wrong
+// creds → 401). It writes 401 and returns false on any mismatch.
 func authOK(w http.ResponseWriter, r *http.Request) bool {
-	if _, _, ok := r.BasicAuth(); ok {
+	if user, pass, ok := r.BasicAuth(); ok && user == wantUser && pass == wantPass {
 		return true
 	}
 	w.Header().Set("WWW-Authenticate", `Basic realm="fakevault"`)
-	http.Error(w, "missing basic auth", http.StatusUnauthorized)
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
 	return false
 }
 

--- a/scenarios/007-fakevault-hermetic-e2e.md
+++ b/scenarios/007-fakevault-hermetic-e2e.md
@@ -1,0 +1,40 @@
+---
+status: active
+---
+
+# Scenario 007: hermetic end-to-end read via the fake TeamVault server
+
+Validates `teamvault-cli` end-to-end against `cmd/fakevault` — a fake TeamVault HTTP server with seeded secrets — using a temp config + `TEAMVAULT_PASS` (no live TeamVault, no macOS Keychain, no personal probe key). Exercises the real HTTP connector, Basic-auth header, and JSON parse path that `--staging` (pure fixtures) and unit tests do not. This is the CI-runnable variant of scenario 001; CI runs it via `make e2e`.
+
+The fastest path is `make e2e` (builds both binaries, starts fakevault, asserts, cleans up). The steps below are the manual walk it automates.
+
+## Setup
+
+- [ ] `go build -C ~/Documents/workspaces/sm-teamvault-cli -o /tmp/teamvault-cli .`
+- [ ] `go build -C ~/Documents/workspaces/sm-teamvault-cli -o /tmp/fakevault ./cmd/fakevault`
+- [ ] `/tmp/fakevault --addr 127.0.0.1:0 >/tmp/fv.log 2>&1 & FV_PID=$!`
+- [ ] `URL=$(sed -n 's#^fakevault listening on ##p' /tmp/fv.log)` (repeat until non-empty)
+- [ ] `printf '{"url":"%s","user":"test"}\n' "$URL" > /tmp/fv-config.json`
+- [ ] `export TEAMVAULT_CONFIG=/tmp/fv-config.json TEAMVAULT_PASS=test`
+
+## Action
+
+- [ ] `PW=$(/tmp/teamvault-cli password --teamvault-key demo)`
+- [ ] `USER=$(/tmp/teamvault-cli username --teamvault-key demo)`
+- [ ] `URLOUT=$(/tmp/teamvault-cli url --teamvault-key demo)`
+- [ ] `FILE=$(/tmp/teamvault-cli file --teamvault-key demo)`
+- [ ] `BYTES=$(/tmp/teamvault-cli password --teamvault-key demo | wc -c | tr -d ' ')`
+
+## Expected
+
+- [ ] `[ "$PW" = "demo-pass-123" ]` (password fetched over real HTTP + Basic auth)
+- [ ] `[ "$USER" = "demo-user" ]`
+- [ ] `[ "$URLOUT" = "https://demo.example/login" ]`
+- [ ] `[ "$FILE" = "demo-file-contents" ]` (file goes through the current-revision → `/data` path)
+- [ ] `[ "$BYTES" = "13" ]` (no trailing newline — `demo-pass-123` is 13 bytes)
+
+## Cleanup
+
+```bash
+kill "$FV_PID" 2>/dev/null; rm -f /tmp/teamvault-cli /tmp/fakevault /tmp/fv.log /tmp/fv-config.json
+```

--- a/scenarios/007-fakevault-hermetic-e2e.md
+++ b/scenarios/007-fakevault-hermetic-e2e.md
@@ -8,7 +8,7 @@ Validates `teamvault-cli` end-to-end against `cmd/fakevault` — a fake TeamVaul
 
 Setup/assert helpers live in `scenarios/helper/lib.sh` (same convention as vault-cli / dark-factory). CI runs the whole thing via `make e2e`; the fastest local path is also `make e2e`.
 
-Covered cases: `password`, `username`, `url`, `file`, `config parse`, `not-found error`, config-via-env (`TEAMVAULT_CONFIG`), config-via-flag (`--teamvault-config`), no-trailing-newline.
+Covered cases: `password`, `username`, `url`, `file`, `config parse`, `config generate`, `not-found error`, `auth failure (401)`, config-via-env (`TEAMVAULT_CONFIG`), config-via-flag (`--teamvault-config`), no-trailing-newline.
 
 ## Setup
 
@@ -30,6 +30,11 @@ assert_eq "file"     "demo-file-contents"         "$("$TV" file --teamvault-key 
 assert_eq "config parse" "user=demo-user pass=demo-pass-123" \
 	"$(printf 'user={{ teamvaultUser "demo" }} pass={{ teamvaultPassword "demo" }}' | "$TV" config parse)"
 assert_exit_nonzero "not-found error" "$TV" password --teamvault-key nope-does-not-exist
+mkdir -p "$WORK_DIR/gen-src" && printf 'db_pass={{ teamvaultPassword "demo" }}' >"$WORK_DIR/gen-src/app.conf"
+"$TV" config generate --source-dir "$WORK_DIR/gen-src" --target-dir "$WORK_DIR/gen-out"
+assert_eq "config generate" "db_pass=demo-pass-123" "$(cat "$WORK_DIR/gen-out/app.conf")"
+printf '{"url":"%s","user":"test","pass":"wrong"}\n' "$FV_URL" >"$WORK_DIR/badconfig.json"
+assert_exit_nonzero "auth failure (401)" "$TV" password --teamvault-config "$WORK_DIR/badconfig.json" --teamvault-key demo
 assert_eq "config via env"  "demo-user" "$("$TV" username --teamvault-key demo)"
 assert_eq "config via flag" "demo-user" \
 	"$(env -u TEAMVAULT_CONFIG "$TV" username --teamvault-config "$WORK_DIR/config.json" --teamvault-key demo)"

--- a/scenarios/007-fakevault-hermetic-e2e.md
+++ b/scenarios/007-fakevault-hermetic-e2e.md
@@ -2,39 +2,43 @@
 status: active
 ---
 
-# Scenario 007: hermetic end-to-end read via the fake TeamVault server
+# Scenario 007: hermetic end-to-end via the fake TeamVault server
 
-Validates `teamvault-cli` end-to-end against `cmd/fakevault` — a fake TeamVault HTTP server with seeded secrets — using a temp config + `TEAMVAULT_PASS` (no live TeamVault, no macOS Keychain, no personal probe key). Exercises the real HTTP connector, Basic-auth header, and JSON parse path that `--staging` (pure fixtures) and unit tests do not. This is the CI-runnable variant of scenario 001; CI runs it via `make e2e`.
+Validates `teamvault-cli` end-to-end against `cmd/fakevault` — a fake TeamVault HTTP server with seeded secrets — using a temp config file that carries url + user + pass (no live TeamVault, no macOS Keychain, no personal probe key). Exercises the real HTTP connector, Basic-auth header, and JSON parse path that `--staging` (pure fixtures) and unit tests do not.
 
-The fastest path is `make e2e` (builds both binaries, starts fakevault, asserts, cleans up). The steps below are the manual walk it automates.
+Setup/assert helpers live in `scenarios/helper/lib.sh` (same convention as vault-cli / dark-factory). CI runs the whole thing via `make e2e`; the fastest local path is also `make e2e`.
+
+Covered cases: `password`, `username`, `url`, `file`, `config parse`, `not-found error`, config-via-env (`TEAMVAULT_CONFIG`), config-via-flag (`--teamvault-config`), no-trailing-newline.
 
 ## Setup
 
-- [ ] `go build -C ~/Documents/workspaces/sm-teamvault-cli -o /tmp/teamvault-cli .`
-- [ ] `go build -C ~/Documents/workspaces/sm-teamvault-cli -o /tmp/fakevault ./cmd/fakevault`
-- [ ] `/tmp/fakevault --addr 127.0.0.1:0 >/tmp/fv.log 2>&1 & FV_PID=$!`
-- [ ] `URL=$(sed -n 's#^fakevault listening on ##p' /tmp/fv.log)` (repeat until non-empty)
-- [ ] `printf '{"url":"%s","user":"test"}\n' "$URL" > /tmp/fv-config.json`
-- [ ] `export TEAMVAULT_CONFIG=/tmp/fv-config.json TEAMVAULT_PASS=test`
+```bash
+source ~/Documents/workspaces/sm-teamvault-cli/scenarios/helper/lib.sh
+build_binaries      # builds teamvault-cli + fakevault to a temp dir, sets $TV
+start_fakevault     # starts the server, writes a temp config (url+user+pass), exports TEAMVAULT_CONFIG
+```
 
-## Action
+- [ ] `$TV` and `$WORK_DIR/config.json` exist; `fakevault` is listening (`$FV_URL` non-empty)
 
-- [ ] `PW=$(/tmp/teamvault-cli password --teamvault-key demo)`
-- [ ] `USER=$(/tmp/teamvault-cli username --teamvault-key demo)`
-- [ ] `URLOUT=$(/tmp/teamvault-cli url --teamvault-key demo)`
-- [ ] `FILE=$(/tmp/teamvault-cli file --teamvault-key demo)`
-- [ ] `BYTES=$(/tmp/teamvault-cli password --teamvault-key demo | wc -c | tr -d ' ')`
+## Action + Expected
 
-## Expected
+```bash
+assert_eq "password" "demo-pass-123"              "$("$TV" password --teamvault-key demo)"
+assert_eq "username" "demo-user"                  "$("$TV" username --teamvault-key demo)"
+assert_eq "url"      "https://demo.example/login" "$("$TV" url --teamvault-key demo)"
+assert_eq "file"     "demo-file-contents"         "$("$TV" file --teamvault-key demo)"
+assert_eq "config parse" "user=demo-user pass=demo-pass-123" \
+	"$(printf 'user={{ teamvaultUser "demo" }} pass={{ teamvaultPassword "demo" }}' | "$TV" config parse)"
+assert_exit_nonzero "not-found error" "$TV" password --teamvault-key nope-does-not-exist
+assert_eq "config via env"  "demo-user" "$("$TV" username --teamvault-key demo)"
+assert_eq "config via flag" "demo-user" \
+	"$(env -u TEAMVAULT_CONFIG "$TV" username --teamvault-config "$WORK_DIR/config.json" --teamvault-key demo)"
+assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
+scenario_done   # prints "e2e: PASS" and exits non-zero if any assertion failed
+```
 
-- [ ] `[ "$PW" = "demo-pass-123" ]` (password fetched over real HTTP + Basic auth)
-- [ ] `[ "$USER" = "demo-user" ]`
-- [ ] `[ "$URLOUT" = "https://demo.example/login" ]`
-- [ ] `[ "$FILE" = "demo-file-contents" ]` (file goes through the current-revision → `/data` path)
-- [ ] `[ "$BYTES" = "13" ]` (no trailing newline — `demo-pass-123` is 13 bytes)
+- [ ] All assertions print `ok:` and `scenario_done` reports `e2e: PASS`
 
 ## Cleanup
 
-```bash
-kill "$FV_PID" 2>/dev/null; rm -f /tmp/teamvault-cli /tmp/fakevault /tmp/fv.log /tmp/fv-config.json
-```
+`scenarios/helper/lib.sh` installs an EXIT trap that kills `fakevault` and removes `$WORK_DIR` — no manual cleanup needed.

--- a/scenarios/helper/lib.sh
+++ b/scenarios/helper/lib.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Shared helpers for teamvault-cli scenarios and `make e2e`. Mirrors the
+# convention in vault-cli / dark-factory (build_binary + assert_* + scenario_done).
+# Fakes the external TeamVault dependency with cmd/fakevault (cf. dark-factory's
+# local-bare-remote in setup_sandbox_copy).
+#
+# Usage:
+#   source scenarios/helper/lib.sh
+#   build_binaries; start_fakevault
+#   assert_eq "desc" "expected" "$actual"
+#   assert_exit_nonzero "desc" some-command --with args
+#   scenario_done
+
+# Repo root, derived from this file's location (works in worktrees too).
+TV_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+_FAIL=0
+FV_PID=""
+
+_cleanup() {
+	[ -n "$FV_PID" ] && kill "$FV_PID" 2>/dev/null || true
+	[ -n "${WORK_DIR:-}" ] && rm -rf "$WORK_DIR"
+}
+trap _cleanup EXIT
+
+# build_binaries builds teamvault-cli + fakevault into a temp dir and sets $TV.
+build_binaries() {
+	WORK_DIR="$(mktemp -d)"
+	go build -C "$TV_ROOT" -o "$WORK_DIR/teamvault-cli" . || exit 1
+	go build -C "$TV_ROOT" -o "$WORK_DIR/fakevault" ./cmd/fakevault || exit 1
+	TV="$WORK_DIR/teamvault-cli"
+}
+
+# start_fakevault launches the fake server on an OS-assigned port, writes a temp
+# config (url+user+pass) pointing at it, and exports TEAMVAULT_CONFIG.
+start_fakevault() {
+	"$WORK_DIR/fakevault" --addr 127.0.0.1:0 >"$WORK_DIR/fv.log" 2>&1 &
+	FV_PID=$!
+	FV_URL=""
+	for _ in $(seq 1 100); do
+		FV_URL="$(sed -n 's#^fakevault listening on ##p' "$WORK_DIR/fv.log")"
+		[ -n "$FV_URL" ] && break
+		sleep 0.1
+	done
+	if [ -z "$FV_URL" ]; then
+		echo "fakevault did not start"; cat "$WORK_DIR/fv.log"; exit 1
+	fi
+	# Password lives in the config file so the Keychain is never consulted — the
+	# CI runner has no macOS Keychain / freedesktop secret service.
+	printf '{"url":"%s","user":"test","pass":"test"}\n' "$FV_URL" >"$WORK_DIR/config.json"
+	export TEAMVAULT_CONFIG="$WORK_DIR/config.json"
+}
+
+# assert_eq <desc> <expected> <actual>
+assert_eq() {
+	if [ "$2" = "$3" ]; then
+		echo "  ok: $1"
+	else
+		echo "  FAIL: $1 — expected '$2' got '$3'"; _FAIL=1
+	fi
+}
+
+# assert_exit_nonzero <desc> <command...>
+assert_exit_nonzero() {
+	local desc="$1"; shift
+	if "$@" >/dev/null 2>&1; then
+		echo "  FAIL: $desc — expected non-zero exit"; _FAIL=1
+	else
+		echo "  ok: $desc"
+	fi
+}
+
+# scenario_done reports and exits non-zero if any assertion failed.
+scenario_done() {
+	if [ "$_FAIL" -eq 0 ]; then
+		echo "e2e: PASS"
+	else
+		echo "e2e: FAIL"; exit 1
+	fi
+}

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -3,63 +3,40 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 #
-# Hermetic end-to-end test: start the fake TeamVault server (cmd/fakevault),
-# point the real teamvault-cli binary at it via a temp config + TEAMVAULT_PASS
-# (no Keychain, no live TeamVault), and assert the seeded secret values.
-set -euo pipefail
+# Hermetic end-to-end test: start cmd/fakevault and drive the real teamvault-cli
+# binary against it (no live TeamVault, no Keychain). Shares setup/assert helpers
+# with the scenarios via scenarios/helper/lib.sh.
+set -uo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TMP="$(mktemp -d)"
-FV_PID=""
-cleanup() {
-	[ -n "$FV_PID" ] && kill "$FV_PID" 2>/dev/null || true
-	rm -rf "$TMP"
-}
-trap cleanup EXIT
+source "$(cd "$(dirname "$0")/.." && pwd)/scenarios/helper/lib.sh"
 
 echo "e2e: building binaries"
-go build -C "$ROOT" -o "$TMP/teamvault-cli" .
-go build -C "$ROOT" -o "$TMP/fakevault" ./cmd/fakevault
-
+build_binaries
 echo "e2e: starting fakevault"
-"$TMP/fakevault" --addr 127.0.0.1:0 >"$TMP/fv.log" 2>&1 &
-FV_PID=$!
+start_fakevault
+echo "e2e: fakevault at $FV_URL"
 
-URL=""
-for _ in $(seq 1 50); do
-	URL="$(sed -n 's#^fakevault listening on ##p' "$TMP/fv.log")"
-	[ -n "$URL" ] && break
-	sleep 0.1
-done
-if [ -z "$URL" ]; then
-	echo "e2e: fakevault did not start"; cat "$TMP/fv.log"; exit 1
-fi
-echo "e2e: fakevault at $URL"
+# Secret reads (config resolved via TEAMVAULT_CONFIG env — set by start_fakevault).
+assert_eq "password" "demo-pass-123"              "$("$TV" password --teamvault-key demo)"
+assert_eq "username" "demo-user"                  "$("$TV" username --teamvault-key demo)"
+assert_eq "url"      "https://demo.example/login" "$("$TV" url --teamvault-key demo)"
+assert_eq "file"     "demo-file-contents"         "$("$TV" file --teamvault-key demo)"
 
-printf '{"url":"%s","user":"test"}\n' "$URL" >"$TMP/config.json"
-export TEAMVAULT_CONFIG="$TMP/config.json" TEAMVAULT_PASS="test"
+# config parse — Go-template funcs resolve secrets from stdin to stdout.
+assert_eq "config parse" "user=demo-user pass=demo-pass-123" \
+	"$(printf 'user={{ teamvaultUser "demo" }} pass={{ teamvaultPassword "demo" }}' | "$TV" config parse)"
 
-fail=0
-check() { # check <desc> <expected> <actual>
-	if [ "$2" = "$3" ]; then
-		echo "  ok: $1"
-	else
-		echo "  FAIL: $1 — expected '$2' got '$3'"; fail=1
-	fi
-}
+# not-found — an unknown key errors (non-zero exit).
+assert_exit_nonzero "not-found error" "$TV" password --teamvault-key nope-does-not-exist
 
-check "password demo"   "demo-pass-123"               "$("$TMP/teamvault-cli" password --teamvault-key demo)"
-check "username demo"   "demo-user"                   "$("$TMP/teamvault-cli" username --teamvault-key demo)"
-check "url demo"        "https://demo.example/login"  "$("$TMP/teamvault-cli" url --teamvault-key demo)"
-check "file demo"       "demo-file-contents"          "$("$TMP/teamvault-cli" file --teamvault-key demo)"
-check "password AbC123" "s3cr3t-value"                "$("$TMP/teamvault-cli" password --teamvault-key AbC123)"
+# config via env var (TEAMVAULT_CONFIG) — already exported; resolve without a flag.
+assert_eq "config via env" "demo-user" "$("$TV" username --teamvault-key demo)"
 
-# Basic-auth-safe: raw output must have NO trailing newline ("demo-pass-123" = 13 bytes).
-BYTES="$("$TMP/teamvault-cli" password --teamvault-key demo | wc -c | tr -d ' ')"
-check "no trailing newline (byte count)" "13" "$BYTES"
+# config via flag (--teamvault-config) — with TEAMVAULT_CONFIG unset, the flag wins.
+assert_eq "config via flag" "demo-user" \
+	"$(env -u TEAMVAULT_CONFIG "$TV" username --teamvault-config "$WORK_DIR/config.json" --teamvault-key demo)"
 
-if [ "$fail" -eq 0 ]; then
-	echo "e2e: PASS"
-else
-	echo "e2e: FAIL"; exit 1
-fi
+# Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
+assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
+
+scenario_done

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Hermetic end-to-end test: start the fake TeamVault server (cmd/fakevault),
+# point the real teamvault-cli binary at it via a temp config + TEAMVAULT_PASS
+# (no Keychain, no live TeamVault), and assert the seeded secret values.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+FV_PID=""
+cleanup() {
+	[ -n "$FV_PID" ] && kill "$FV_PID" 2>/dev/null || true
+	rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+echo "e2e: building binaries"
+go build -C "$ROOT" -o "$TMP/teamvault-cli" .
+go build -C "$ROOT" -o "$TMP/fakevault" ./cmd/fakevault
+
+echo "e2e: starting fakevault"
+"$TMP/fakevault" --addr 127.0.0.1:0 >"$TMP/fv.log" 2>&1 &
+FV_PID=$!
+
+URL=""
+for _ in $(seq 1 50); do
+	URL="$(sed -n 's#^fakevault listening on ##p' "$TMP/fv.log")"
+	[ -n "$URL" ] && break
+	sleep 0.1
+done
+if [ -z "$URL" ]; then
+	echo "e2e: fakevault did not start"; cat "$TMP/fv.log"; exit 1
+fi
+echo "e2e: fakevault at $URL"
+
+printf '{"url":"%s","user":"test"}\n' "$URL" >"$TMP/config.json"
+export TEAMVAULT_CONFIG="$TMP/config.json" TEAMVAULT_PASS="test"
+
+fail=0
+check() { # check <desc> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		echo "  ok: $1"
+	else
+		echo "  FAIL: $1 — expected '$2' got '$3'"; fail=1
+	fi
+}
+
+check "password demo"   "demo-pass-123"               "$("$TMP/teamvault-cli" password --teamvault-key demo)"
+check "username demo"   "demo-user"                   "$("$TMP/teamvault-cli" username --teamvault-key demo)"
+check "url demo"        "https://demo.example/login"  "$("$TMP/teamvault-cli" url --teamvault-key demo)"
+check "file demo"       "demo-file-contents"          "$("$TMP/teamvault-cli" file --teamvault-key demo)"
+check "password AbC123" "s3cr3t-value"                "$("$TMP/teamvault-cli" password --teamvault-key AbC123)"
+
+# Basic-auth-safe: raw output must have NO trailing newline ("demo-pass-123" = 13 bytes).
+BYTES="$("$TMP/teamvault-cli" password --teamvault-key demo | wc -c | tr -d ' ')"
+check "no trailing newline (byte count)" "13" "$BYTES"
+
+if [ "$fail" -eq 0 ]; then
+	echo "e2e: PASS"
+else
+	echo "e2e: FAIL"; exit 1
+fi

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -36,6 +36,17 @@ assert_eq "config via env" "demo-user" "$("$TV" username --teamvault-key demo)"
 assert_eq "config via flag" "demo-user" \
 	"$(env -u TEAMVAULT_CONFIG "$TV" username --teamvault-config "$WORK_DIR/config.json" --teamvault-key demo)"
 
+# config generate — render a template directory tree to a target directory.
+mkdir -p "$WORK_DIR/gen-src"
+printf 'db_pass={{ teamvaultPassword "demo" }}' >"$WORK_DIR/gen-src/app.conf"
+"$TV" config generate --source-dir "$WORK_DIR/gen-src" --target-dir "$WORK_DIR/gen-out"
+assert_eq "config generate" "db_pass=demo-pass-123" "$(cat "$WORK_DIR/gen-out/app.conf")"
+
+# auth failure — a config with the wrong password gets 401 → non-zero exit.
+printf '{"url":"%s","user":"test","pass":"wrong"}\n' "$FV_URL" >"$WORK_DIR/badconfig.json"
+assert_exit_nonzero "auth failure (401)" \
+	"$TV" password --teamvault-config "$WORK_DIR/badconfig.json" --teamvault-key demo
+
 # Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
 assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
 


### PR DESCRIPTION
## What

Add **`cmd/fakevault`** — a fake TeamVault HTTP server with seeded secrets — and wire it into a hermetic, CI-runnable end-to-end test.

- **`cmd/fakevault/main.go`**: implements the 4 read endpoints the connector calls (`/api/secrets/{key}/`, `/api/secret-revisions/{key}/data`, `/api/secrets/?search=`, Basic auth). Seeded fixtures (`demo`, `AbC123`). `--addr` flag, prints the listen address. Timeout-configured `http.Server`. **Not shipped** — goreleaser builds `main: .` only.
- **`make e2e`** (`scripts/e2e.sh`): builds both binaries, starts fakevault, points the real `teamvault-cli` at it via a temp config + `TEAMVAULT_PASS` (no Keychain), asserts `password`/`username`/`url`/`file` + the no-trailing-newline guarantee.
- **CI job `e2e`**: runs `make e2e` on every PR.
- **`scenarios/007`**: documents the hermetic flow.

## Why

Scenarios 001–006 only run on the author's machine against live TeamVault + Keychain + a personal probe key (`lO4K1w`) — they can't run in CI and break for anyone else. fakevault makes the read scenarios **hermetic and CI-runnable**, and exercises the **real HTTP connector + Basic-auth + JSON-parse path** that `--staging` (pure fixtures) and unit tests never touch. The `login`/Keychain scenario (002) stays macOS-manual by design.

## Verification

- `make precommit` green (150 specs, 0 lint, 0 vuln).
- `make e2e` green: all 5 secret asserts + no-trailing-newline pass against the real binary ↔ fakevault over HTTP.