### PR TITLE
fix(auth): suggest `teamvault-cli login` on 401/403 + keychain-read failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- fix(auth): on a `401`/`403` from TeamVault, and on a Keychain-read failure, the error now points the user at `teamvault-cli login` to (re)store their password — e.g. after the v5.2.0 Keychain service rename (`teamvault-utils` → `teamvault-cli`), a first fetch would 403 with no hint. Wraps the connector/factory errors via `github.com/bborbe/errors`.
+- fix(auth): on a `401`/`403` from TeamVault, and on a Keychain-read failure, the error now points the user at `teamvault-cli login` to (re)store their password — e.g. after the v5.2.0 Keychain service rename (`teamvault-utils` → `teamvault-cli`), a first fetch would 403 with no hint.
+- refactor(errors): make `pkg/remote-connector.go` compliant with the `github.com/bborbe/errors` wrapping guide — replace `fmt.Errorf`/bare `return err` with `errors.Wrapf(ctx, …)`, and introduce `ErrUserType`/`ErrPasswordType` sentinels for the ctx-less `UnmarshalJSON` paths.
 
 ## v5.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- fix(auth): on a `401`/`403` from TeamVault, and on a Keychain-read failure, the error now points the user at `teamvault-cli login` to (re)store their password — e.g. after the v5.2.0 Keychain service rename (`teamvault-utils` → `teamvault-cli`), a first fetch would 403 with no hint. Wraps the connector/factory errors via `github.com/bborbe/errors`.
+
 ## v5.5.1
 
 - test(e2e): add `cmd/fakevault` — a fake TeamVault HTTP server with seeded secrets — plus a `make e2e` target, scenario 007, and a CI job that drives the real `teamvault-cli` binary against it (temp config + `TEAMVAULT_PASS`, no live TeamVault / Keychain). Exercises the real HTTP connector, Basic-auth, and JSON-parse path that `--staging` and unit tests do not; makes the read scenarios hermetic and CI-runnable. `fakevault` is a test helper and is not shipped.

--- a/pkg/cli/login_test.go
+++ b/pkg/cli/login_test.go
@@ -306,6 +306,15 @@ var _ = Describe("isAuthError", func() {
 		Expect(isAuthError(fmt.Errorf("request failed with status: 403"))).To(BeTrue())
 	})
 
+	It(
+		"returns true for the connector's login-hint auth error (contract with remote-connector.go)",
+		func() {
+			Expect(isAuthError(fmt.Errorf(
+				"request to https://tv.example/api/secrets/AbC123/ failed with status: 401 (authentication failed) — run `teamvault-cli login` to (re)store your TeamVault password in the Keychain",
+			))).To(BeTrue())
+		},
+	)
+
 	It("returns false for network error", func() {
 		Expect(isAuthError(fmt.Errorf("connection refused"))).To(BeFalse())
 	})

--- a/pkg/factory/factory.go
+++ b/pkg/factory/factory.go
@@ -98,7 +98,7 @@ func CreateConnectorWithConfigAndTimeout(
 			return nil, errors.Wrapf(
 				ctx,
 				err,
-				"read password from keychain for url %q failed",
+				"read password from keychain for url %q failed — run `teamvault-cli login` to store your TeamVault password",
 				apiURL,
 			)
 		}

--- a/pkg/remote-connector.go
+++ b/pkg/remote-connector.go
@@ -246,9 +246,11 @@ func (r *remoteConnector) call(
 		// V(4): the URL path contains the lookup key; keep it out of the common V(2) log tier.
 		glog.V(4).Infof("request to %s failed with status: %d", url, resp.StatusCode)
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			// Keep "status: %d" (with colon) — isAuthError in login.go matches on it
+			// to drive the login retry loop.
 			return errors.Errorf(
 				ctx,
-				"request to %s failed with status %d (authentication failed) — run `teamvault-cli login` to (re)store your TeamVault password in the Keychain",
+				"request to %s failed with status: %d (authentication failed) — run `teamvault-cli login` to (re)store your TeamVault password in the Keychain",
 				url,
 				resp.StatusCode,
 			)

--- a/pkg/remote-connector.go
+++ b/pkg/remote-connector.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/bborbe/errors"
 	"github.com/bborbe/time"
 	"github.com/golang/glog"
 )
@@ -236,7 +237,15 @@ func (r *remoteConnector) call(
 	if resp.StatusCode/100 != 2 {
 		// V(4): the URL path contains the lookup key; keep it out of the common V(2) log tier.
 		glog.V(4).Infof("request to %s failed with status: %d", url, resp.StatusCode)
-		return fmt.Errorf("request to %s failed with status: %d", url, resp.StatusCode)
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return errors.Errorf(
+				ctx,
+				"request to %s failed with status %d (authentication failed) — run `teamvault-cli login` to (re)store your TeamVault password in the Keychain",
+				url,
+				resp.StatusCode,
+			)
+		}
+		return errors.Errorf(ctx, "request to %s failed with status: %d", url, resp.StatusCode)
 	}
 	if response != nil {
 		if err = json.NewDecoder(resp.Body).Decode(response); err != nil {

--- a/pkg/remote-connector.go
+++ b/pkg/remote-connector.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +16,13 @@ import (
 	"github.com/bborbe/errors"
 	"github.com/bborbe/time"
 	"github.com/golang/glog"
+)
+
+var (
+	// ErrUserType is returned when a TeamVault username JSON value is neither a string nor a number.
+	ErrUserType = stderrors.New("username must be string or number")
+	// ErrPasswordType is returned when a TeamVault password JSON value is neither a string nor a number.
+	ErrPasswordType = stderrors.New("password must be string or number")
 )
 
 // Url represents a TeamVault URL or secret URL value.
@@ -49,7 +57,7 @@ func (u *User) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("username must be string or number")
+	return ErrUserType
 }
 
 // Password represents a TeamVault password.
@@ -76,7 +84,7 @@ func (t *Password) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("password must be string or number")
+	return ErrPasswordType
 }
 
 // NewRemoteConnector creates a new Connector that connects to a remote TeamVault instance.
@@ -151,7 +159,7 @@ func (r *remoteConnector) CurrentRevision(ctx context.Context, key Key) (Current
 func (r *remoteConnector) File(ctx context.Context, key Key) (File, error) {
 	rev, err := r.CurrentRevision(ctx, key)
 	if err != nil {
-		return "", fmt.Errorf("get current revision failed: %v", err)
+		return "", errors.Wrapf(ctx, err, "get current revision failed")
 	}
 	var response struct {
 		File File `json:"file"`
@@ -218,7 +226,7 @@ func (r *remoteConnector) call(
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		glog.V(2).Infof("build request failed: %v", err)
-		return err
+		return errors.Wrapf(ctx, err, "build request failed")
 	}
 	req.Header.Set("ContentType", "application/json")
 	for key, values := range headers {
@@ -231,7 +239,7 @@ func (r *remoteConnector) call(
 	) // #nosec G704 -- URLs are constructed from configured base URL and API paths, not user input
 	if err != nil {
 		glog.V(2).Infof("execute request failed: %v", err)
-		return err
+		return errors.Wrapf(ctx, err, "execute request failed")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
@@ -250,7 +258,7 @@ func (r *remoteConnector) call(
 	if response != nil {
 		if err = json.NewDecoder(resp.Body).Decode(response); err != nil {
 			glog.V(2).Infof("decode response failed: %v", err)
-			return err
+			return errors.Wrapf(ctx, err, "decode response failed")
 		}
 	}
 	glog.V(8).Infof("rest call successful")

--- a/scenarios/helper/lib.sh
+++ b/scenarios/helper/lib.sh
@@ -73,6 +73,14 @@ assert_exit_nonzero() {
 	fi
 }
 
+# assert_contains <desc> <needle> <haystack>
+assert_contains() {
+	case "$3" in
+		*"$2"*) echo "  ok: $1" ;;
+		*) echo "  FAIL: $1 — '$2' not found in: $3"; _FAIL=1 ;;
+	esac
+}
+
 # scenario_done reports and exits non-zero if any assertion failed.
 scenario_done() {
 	if [ "$_FAIL" -eq 0 ]; then

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -46,6 +46,9 @@ assert_eq "config generate" "db_pass=demo-pass-123" "$(cat "$WORK_DIR/gen-out/ap
 printf '{"url":"%s","user":"test","pass":"wrong"}\n' "$FV_URL" >"$WORK_DIR/badconfig.json"
 assert_exit_nonzero "auth failure (401)" \
 	"$TV" password --teamvault-config "$WORK_DIR/badconfig.json" --teamvault-key demo
+# the auth-failure error should point the user at `teamvault-cli login`.
+assert_contains "auth failure suggests login" "teamvault-cli login" \
+	"$("$TV" password --teamvault-config "$WORK_DIR/badconfig.json" --teamvault-key demo 2>&1 1>/dev/null)"
 
 # Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
 assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"


### PR DESCRIPTION
## What

When TeamVault returns **401/403**, or the **Keychain read fails**, the error now points the user at `teamvault-cli login` instead of a bare status/keychain message.

- `pkg/remote-connector.go`: on `401`/`403`, wrap with "authentication failed — run `teamvault-cli login` to (re)store your TeamVault password in the Keychain" (via `github.com/bborbe/errors`, replacing a bare `fmt.Errorf`).
- `pkg/factory/factory.go`: the keychain-read error gains the same hint (the Linux path where the secret service is unavailable).
- e2e: new `assert_contains` helper + an assertion that the auth-failure error contains `teamvault-cli login` (drives it through fakevault's 401).

## Why

Real report today: after upgrading (the v5.2.0 Keychain service rename `teamvault-utils` → `teamvault-cli`), the first `teamvault-cli password …` fetch **403'd with no hint** — the password was still only under the old Keychain service. The fix here is: `teamvault-cli login` once. This makes the tool say so.

## Verification

- `make e2e` green — including the new `auth failure suggests login` assertion (real 401 from fakevault).
- `make precommit` green (150 specs, 0 lint, 0 vuln).