### PR TITLE
Expand skill secret-safety with cloud-session leak guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- docs(skill): expand the "Handling secrets safely" section of the Claude Code skill with the inbound cloud-session risk — never ask the user to paste a secret, rotate any credential that reaches the transcript, and state the "credentials never leak" rule standalone so it holds for users outside the company who lack the org policy.
+
 ## v5.5.2
 
 - fix(auth): on a `401`/`403` from TeamVault, and on a Keychain-read failure, the error now points the user at `teamvault-cli login` to (re)store their password — e.g. after the v5.2.0 Keychain service rename (`teamvault-utils` → `teamvault-cli`), a first fetch would 403 with no hint.

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -65,7 +65,7 @@ curl -u "$(teamvault-cli username --teamvault-key <KEY>):$(teamvault-cli passwor
 Why it matters in an AI session: the conversation transcript leaves your machine — it is sent to the model provider's cloud, where it may be logged, cached, or indexed, and deleting a message does **not** unsend it. Any secret value that reaches the transcript must be treated as **compromised and rotated in TeamVault**. The whole point of `teamvault-cli` is that the secret is resolved locally, at the moment of use, and never passes through the prompt or the model.
 
 - **Never** ask the user to type or paste a secret value into the session. Ask only for the non-secret **key** (the alphanumeric ID) and let the CLI fetch the value locally.
-- If the user pastes a live credential into the chat anyway, stop and tell them to rotate it in TeamVault — do not reuse it.
+- If the user pastes a live credential into the chat anyway, stop and tell them to rotate it — do not reuse it. Rotation is a web-UI operation (open the secret in TeamVault → Edit → set/regenerate the value); `teamvault-cli` is read-only and cannot rotate it for them.
 - **Never** write a retrieved secret into a file, commit, comment, or the chat transcript. Pipe it directly into the consuming command, or use command substitution as above.
 - Prefer `$(teamvault-cli password --teamvault-key <KEY>)` inline over assigning the value to a visible variable.
 - Do not log, print, or echo the value to confirm it — confirm success by the consuming command's exit status instead.

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -60,6 +60,12 @@ curl -u "$(teamvault-cli username --teamvault-key <KEY>):$(teamvault-cli passwor
 
 ## Handling secrets safely (non-negotiable)
 
+**Credentials never leak — not in output, not in committed files, not in chat.** This rule stands on its own; it does not depend on any external policy or `CLAUDE.md`, so it holds for every user of this CLI, inside or outside the company.
+
+Why it matters in an AI session: the conversation transcript leaves your machine — it is sent to the model provider's cloud, where it may be logged, cached, or indexed, and deleting a message does **not** unsend it. Any secret value that reaches the transcript must be treated as **compromised and rotated in TeamVault**. The whole point of `teamvault-cli` is that the secret is resolved locally, at the moment of use, and never passes through the prompt or the model.
+
+- **Never** ask the user to type or paste a secret value into the session. Ask only for the non-secret **key** (the alphanumeric ID) and let the CLI fetch the value locally.
+- If the user pastes a live credential into the chat anyway, stop and tell them to rotate it in TeamVault — do not reuse it.
 - **Never** write a retrieved secret into a file, commit, comment, or the chat transcript. Pipe it directly into the consuming command, or use command substitution as above.
 - Prefer `$(teamvault-cli password --teamvault-key <KEY>)` inline over assigning the value to a visible variable.
 - Do not log, print, or echo the value to confirm it — confirm success by the consuming command's exit status instead.


### PR DESCRIPTION
## What

Expand the "Handling secrets safely (non-negotiable)" section of the `teamvault` Claude Code skill to cover the **inbound cloud-session** leak surface, which the prior text (outbound-only) missed.

## Why

The conversation transcript is sent to the model provider's cloud and may be logged, cached, or indexed — deleting a message does not unsend it. A secret pasted into the prompt is therefore exposed even if Claude never echoes it. External users of this CLI have no company `CLAUDE.md` guardrail, so the skill must state the rule standalone.

## Changes

- State "credentials never leak" as a self-contained rule (holds for users outside the company).
- Explain the cloud-session risk and mandate **rotation** of any secret that reaches the transcript.
- Add inbound rules: never ask the user to paste a secret; if they do, stop and tell them to rotate.
- Keep existing outbound rules (no echo, command-substitution, `.envrc`).

Docs-only. `make precommit` green (150 specs, 0 lint, 0 vuln).