### PR TITLE
add teamvault-cli:setup command + strip trailing slash from base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- feat(cli): add the `/teamvault-cli:setup` Claude Code command — a guided first-time Seibert setup (Homebrew install, interactive+non-interactive PATH check, XDG config, login instruction, verify). It configures + instructs + verifies but never runs `login` itself, so the interactive password never enters an AI session.
+- fix(url): strip a trailing slash (and surrounding whitespace) from the base TeamVault URL via `Url.Normalize()`, applied in `NewRemoteConnector` and the Keychain read/write. A configured `https://teamvault.seibert.tools/` previously produced a double-slash API path (`…//api/secrets/…`) that 404'd on the first fetch; normalizing in both places also keeps the Keychain key consistent between `login` (write) and fetch (read). Added unit tests + a hermetic trailing-slash e2e case.
+- docs(skill): make the config guidance Seibert-specific — `user` is the LDAP username (hint: the local part of the old `@seibert-media.net` address, `bborbe@seibert-media.net` → `bborbe`), `url` has no trailing slash, and `login` runs in a plain terminal (never paste a secret into an AI session). Point new users at `/teamvault-cli:setup`.
+
 ## v5.5.3
 
 - docs(skill): expand the "Handling secrets safely" section of the Claude Code skill with the inbound cloud-session risk — never ask the user to paste a secret, rotate any credential that reaches the transcript, and state the "credentials never leak" rule standalone so it holds for users outside the company who lack the org policy.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Guided first-time setup of teamvault-cli for Seibert TeamVault (install, config, login hint, verify)
-allowed-tools: Bash, Read, Write, AskUserQuestion
+allowed-tools: Bash(command -v:*), Bash(uname:*), Bash(brew:*), Bash(zsh:*), Bash(mkdir:*), Bash(teamvault-cli:*), Read, Write, AskUserQuestion
 ---
 
 # Set up teamvault-cli (Seibert)
@@ -29,19 +29,13 @@ On Linux, skip Homebrew — use the release binary or `go install` (see Step 2).
 
 ## Step 2 — Install teamvault-cli
 
-**macOS (Homebrew):**
+macOS (recommended):
 
 ```bash
-brew install seibert-data/tap/teamvault-cli   # or: brew upgrade teamvault-cli
+brew install seibert-data/tap/teamvault-cli   # update later: brew upgrade teamvault-cli
 ```
 
-**Linux (prebuilt binary):**
-
-```bash
-curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/download/teamvault-cli_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz teamvault-cli && sudo install teamvault-cli /usr/local/bin/ && rm teamvault-cli
-```
-
-**Any platform with Go:** `go install github.com/Seibert-Data/teamvault-cli/v5@latest`
+**Linux / Go:** see `docs/getting-started.md` §1 for the platform-specific commands (prebuilt release binary, or `go install github.com/Seibert-Data/teamvault-cli/v5@latest`). Then skip to Step 4 — Homebrew's PATH steps below are macOS-only.
 
 ## Step 3 — PATH check (interactive AND non-interactive)
 
@@ -67,14 +61,7 @@ Determine the two values:
 - **URL** — Seibert is always `https://teamvault.seibert.tools` (**no trailing slash** — the CLI now strips one defensively, but write it clean).
 - **`user`** — the **LDAP username**, NOT an email. Hint to give the user: *it's the local part of your old `@seibert-media.net` address* — e.g. `bborbe@seibert-media.net` → `bborbe`. If they never had that address, it's their Confluence/Jira/LDAP login name. Ask via `AskUserQuestion` if unknown; do not guess.
 
-Write the XDG-default config (respect `$XDG_CONFIG_HOME`; default `~/.config`). Do NOT put a password in the file.
-
-```bash
-cfg="${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli"
-mkdir -p "$cfg"
-```
-
-Write `$cfg/config.json` (substitute the LDAP username):
+Create the XDG-default dir (`mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli"`), then write `config.json` there (substitute the LDAP username; never put a password in the file):
 
 ```json
 {

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,112 @@
+---
+description: Guided first-time setup of teamvault-cli for Seibert TeamVault (install, config, login hint, verify)
+allowed-tools: Bash, Read, Write, AskUserQuestion
+---
+
+# Set up teamvault-cli (Seibert)
+
+Walk a new user through first-time setup of `teamvault-cli` against Seibert TeamVault, end to end. Optimized for the two things people get wrong: the **`user` must be the LDAP username** (not an email), and on macOS **Homebrew's bin must be on the PATH for non-interactive shells** (direnv / `.envrc` run there).
+
+**Never handle the password.** `teamvault-cli login` prompts for it interactively; that value must never enter this session or the transcript. This command configures + instructs + verifies — it does NOT run `login`.
+
+Run the steps in order. Stop and report if a step fails; don't paper over it.
+
+## Step 1 — Homebrew (macOS)
+
+Only on macOS (`uname` = `Darwin`). Check:
+
+```bash
+command -v brew
+```
+
+If missing, tell the user to install it themselves (it needs `sudo` and is interactive — do not run it for them):
+
+> Homebrew isn't installed. In a plain terminal, run:
+> `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+> then re-run `/teamvault-cli:setup`.
+
+On Linux, skip Homebrew — use the release binary or `go install` (see Step 2).
+
+## Step 2 — Install teamvault-cli
+
+**macOS (Homebrew):**
+
+```bash
+brew install seibert-data/tap/teamvault-cli   # or: brew upgrade teamvault-cli
+```
+
+**Linux (prebuilt binary):**
+
+```bash
+curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/download/teamvault-cli_linux_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz teamvault-cli && sudo install teamvault-cli /usr/local/bin/ && rm teamvault-cli
+```
+
+**Any platform with Go:** `go install github.com/Seibert-Data/teamvault-cli/v5@latest`
+
+## Step 3 — PATH check (interactive AND non-interactive)
+
+This is the step that silently breaks `.envrc`/direnv later. Homebrew's bin (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel) must be on the PATH for **both** an interactive login shell and a non-interactive shell.
+
+```bash
+brew_bin="$(brew --prefix 2>/dev/null)/bin"
+echo "brew bin: $brew_bin"
+echo -n "interactive login shell: "; zsh -lic 'command -v teamvault-cli' 2>/dev/null || echo "NOT FOUND"
+echo -n "non-interactive shell:   "; zsh -c 'command -v teamvault-cli' 2>/dev/null || echo "NOT FOUND"
+```
+
+- **Both found** → PATH is fine, continue.
+- **Interactive found, non-interactive NOT** → the brew shellenv is only in an interactive rc file. direnv/`.envrc` (non-interactive) won't see `teamvault-cli`. Tell the user to add it where non-interactive shells read it:
+  > Add this line to `~/.zshenv` (sourced by every shell, including non-interactive) — or ensure your `~/.zprofile` `brew shellenv` line is present and your terminal starts a login shell:
+  > `eval "$(/opt/homebrew/bin/brew shellenv)"`  *(use `/usr/local/bin` on Intel)*
+- **Neither found** → the install didn't land on PATH at all; have the user add the `brew shellenv` line above to `~/.zprofile` and open a new terminal, then re-run this command.
+
+## Step 4 — Configure
+
+Determine the two values:
+
+- **URL** — Seibert is always `https://teamvault.seibert.tools` (**no trailing slash** — the CLI now strips one defensively, but write it clean).
+- **`user`** — the **LDAP username**, NOT an email. Hint to give the user: *it's the local part of your old `@seibert-media.net` address* — e.g. `bborbe@seibert-media.net` → `bborbe`. If they never had that address, it's their Confluence/Jira/LDAP login name. Ask via `AskUserQuestion` if unknown; do not guess.
+
+Write the XDG-default config (respect `$XDG_CONFIG_HOME`; default `~/.config`). Do NOT put a password in the file.
+
+```bash
+cfg="${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli"
+mkdir -p "$cfg"
+```
+
+Write `$cfg/config.json` (substitute the LDAP username):
+
+```json
+{
+    "url": "https://teamvault.seibert.tools",
+    "user": "<ldap-username>"
+}
+```
+
+If `~/.teamvault.json` already exists (legacy default), point that out — the XDG file takes precedence.
+
+## Step 5 — Login (user runs this, NOT Claude)
+
+`teamvault-cli login` verifies the password and stores it in the macOS Keychain. It is **interactive** and prompts for the password — so the user must run it themselves in a plain terminal. Tell them, verbatim:
+
+> In a **plain terminal** (not here in Claude), run:
+> `teamvault-cli login`
+> Enter your TeamVault password when prompted. It's stored in your macOS Keychain; you won't need to type it again.
+
+Do not run `login` yourself and do not ask the user to paste the password here. Wait for them to confirm they've done it.
+
+*(On Linux/Windows there's no Keychain backend yet — the user supplies the password via `TEAMVAULT_PASS` or the config file instead. Note this only if they're not on macOS.)*
+
+## Step 6 — Verify
+
+After the user confirms login, test end to end with a **non-secret** call — ask for a TeamVault key they can read (the alphanumeric ID from a secret's URL), then check exit status without printing any value:
+
+```bash
+teamvault-cli username --teamvault-key <KEY> >/dev/null && echo "OK — teamvault-cli is set up" || echo "FAILED — see error above"
+```
+
+- **OK** → setup complete. Mention the `.envrc` pattern for project use: `export FOO=$(teamvault-cli password --teamvault-key <KEY>)`.
+- **403 / authentication failed** → the password isn't in the Keychain for this instance. Have the user re-run `teamvault-cli login` in a plain terminal (the error message says so since v5.5.2).
+- **key not found / 404** → wrong `user` (not the LDAP name) or wrong key. Recheck Step 4's username.
+
+Never print, echo, or log a resolved secret value to confirm success — the exit status is the confirmation.

--- a/pkg/keychain_impl.go
+++ b/pkg/keychain_impl.go
@@ -55,6 +55,9 @@ type darwinKeychain struct {
 }
 
 func (d *darwinKeychain) ReadPassword(ctx context.Context, url Url) (Password, error) {
+	// Normalize so the lookup key matches what WritePassword stored, regardless
+	// of a trailing slash on the configured URL.
+	url = url.Normalize()
 	if url == "" {
 		glog.V(3).Infof("keychain read skipped: empty URL")
 		return "", nil
@@ -76,6 +79,9 @@ func (d *darwinKeychain) ReadPassword(ctx context.Context, url Url) (Password, e
 }
 
 func (d *darwinKeychain) WritePassword(ctx context.Context, url Url, password Password) error {
+	// Normalize so the stored key matches what ReadPassword looks up, regardless
+	// of a trailing slash on the configured URL.
+	url = url.Normalize()
 	if url == "" {
 		glog.V(3).Infof("keychain write skipped: empty URL")
 		return nil

--- a/pkg/keychain_impl_test.go
+++ b/pkg/keychain_impl_test.go
@@ -96,6 +96,19 @@ var _ = Describe("darwinKeychain", func() {
 				Expect(fakeKeyring.GetCallCount()).To(Equal(0))
 			})
 		})
+
+		Context("when URL has a trailing slash", func() {
+			BeforeEach(func() {
+				fakeKeyring.GetReturns("mysecret", nil)
+			})
+
+			It("keys on the normalized (trimmed) URL so it matches WritePassword", func() {
+				_, _ = kc.ReadPassword(ctx, "https://vault.example.com/")
+				Expect(fakeKeyring.GetCallCount()).To(Equal(1))
+				_, user := fakeKeyring.GetArgsForCall(0)
+				Expect(user).To(Equal("https://vault.example.com"))
+			})
+		})
 	})
 
 	Describe("WritePassword", func() {
@@ -148,6 +161,19 @@ var _ = Describe("darwinKeychain", func() {
 				err := kc.WritePassword(ctx, "", "mysecret")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(fakeKeyring.SetCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when URL has a trailing slash", func() {
+			BeforeEach(func() {
+				fakeKeyring.SetReturns(nil)
+			})
+
+			It("keys on the normalized (trimmed) URL so ReadPassword matches", func() {
+				_ = kc.WritePassword(ctx, "https://vault.example.com/", "mysecret")
+				Expect(fakeKeyring.SetCallCount()).To(Equal(1))
+				_, user, _ := fakeKeyring.SetArgsForCall(0)
+				Expect(user).To(Equal("https://vault.example.com"))
 			})
 		})
 

--- a/pkg/remote-connector.go
+++ b/pkg/remote-connector.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/bborbe/errors"
 	"github.com/bborbe/time"
@@ -31,6 +32,16 @@ type Url string
 // String returns the string representation of the Url.
 func (u Url) String() string {
 	return string(u)
+}
+
+// Normalize returns the Url with surrounding whitespace and trailing slashes
+// removed. TeamVault API paths are built as "<url>/api/secrets/...", so a base
+// URL that ends in a slash (e.g. the value copied from a browser,
+// "https://teamvault.seibert.tools/") would produce a double-slash path that
+// 404s. It is also the key the Keychain stores the password under, so login
+// (write) and fetch (read) must normalize identically or the lookup misses.
+func (u Url) Normalize() Url {
+	return Url(strings.TrimRight(strings.TrimSpace(string(u)), "/"))
 }
 
 // User represents a TeamVault username.
@@ -97,7 +108,7 @@ func NewRemoteConnector(
 ) Connector {
 	return &remoteConnector{
 		httpClient:      httpClient,
-		url:             url,
+		url:             url.Normalize(),
 		user:            user,
 		pass:            pass,
 		currentDateTime: currentDateTime,

--- a/pkg/url_normalize_test.go
+++ b/pkg/url_normalize_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package teamvault_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	libhttp "github.com/bborbe/http"
+	libtime "github.com/bborbe/time"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+)
+
+var _ = Describe("Url.Normalize", func() {
+	DescribeTable(
+		"trims trailing slashes and surrounding whitespace",
+		func(input teamvault.Url, expected teamvault.Url) {
+			Expect(input.Normalize()).To(Equal(expected))
+		},
+		Entry(
+			"already clean",
+			teamvault.Url("https://teamvault.seibert.tools"),
+			teamvault.Url("https://teamvault.seibert.tools"),
+		),
+		Entry(
+			"single trailing slash",
+			teamvault.Url("https://teamvault.seibert.tools/"),
+			teamvault.Url("https://teamvault.seibert.tools"),
+		),
+		Entry(
+			"multiple trailing slashes",
+			teamvault.Url("https://teamvault.seibert.tools//"),
+			teamvault.Url("https://teamvault.seibert.tools"),
+		),
+		Entry(
+			"surrounding whitespace",
+			teamvault.Url("  https://teamvault.seibert.tools/  "),
+			teamvault.Url("https://teamvault.seibert.tools"),
+		),
+		Entry("empty stays empty", teamvault.Url(""), teamvault.Url("")),
+	)
+})
+
+var _ = Describe("RemoteConnector with trailing-slash URL", func() {
+	var ctx context.Context
+	var server *ghttp.Server
+	var remoteConnector teamvault.Connector
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		server = ghttp.NewServer()
+		// Build the connector with a URL that ends in a slash — the value a
+		// Seibert user copies from the browser (https://teamvault.seibert.tools/).
+		// Without normalization this produces a double-slash path that 404s.
+		remoteConnector = teamvault.NewRemoteConnector(
+			libhttp.CreateDefaultHttpClient(),
+			teamvault.Url(server.URL()+"/"),
+			teamvault.User("user"),
+			teamvault.Password("pass"),
+			libtime.NewCurrentDateTime(),
+		)
+		server.RouteToHandler(
+			http.MethodGet,
+			"/api/secrets/key123/",
+			func(resp http.ResponseWriter, req *http.Request) {
+				resp.WriteHeader(http.StatusOK)
+				fmt.Fprintf(resp, `{"username":"myuser"}`)
+			},
+		)
+	})
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("builds a single-slash request path (no // after the host)", func() {
+		result, err := remoteConnector.User(ctx, "key123")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(teamvault.User("myuser")))
+	})
+})

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -53,4 +53,11 @@ assert_contains "auth failure suggests login" "teamvault-cli login" \
 # Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
 assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
 
+# trailing-slash URL — a config whose url ends in "/" must still resolve (the CLI
+# normalizes it; without that, "<url>//api/secrets/…" 404s). This is the exact
+# value a user copies from the browser.
+printf '{"url":"%s/","user":"test","pass":"test"}\n' "$FV_URL" >"$WORK_DIR/slashconfig.json"
+assert_eq "trailing-slash url resolves" "demo-user" \
+	"$(env -u TEAMVAULT_CONFIG "$TV" username --teamvault-config "$WORK_DIR/slashconfig.json" --teamvault-key demo)"
+
 scenario_done

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -34,7 +34,7 @@ go install github.com/Seibert-Data/teamvault-cli/v5@latest   # installs to $(go 
 Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy). At **Seibert** the file is:
 
 ```json
-{ "url": "https://teamvault.seibert.tools", "user": "bborbe" }
+{ "url": "https://teamvault.seibert.tools", "user": "<your-ldap-username>" }
 ```
 
 Two things people get wrong here:

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -31,15 +31,22 @@ curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/downloa
 go install github.com/Seibert-Data/teamvault-cli/v5@latest   # installs to $(go env GOPATH)/bin
 ```
 
-Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy). Check for either:
+Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy). At **Seibert** the file is:
 
 ```json
-{ "url": "https://teamvault.your-company.example", "user": "your-teamvault-username" }
+{ "url": "https://teamvault.seibert.tools", "user": "bborbe" }
 ```
+
+Two things people get wrong here:
+
+- **`user` is your LDAP username, not an email.** It's the local part of your old `@seibert-media.net` address — e.g. `bborbe@seibert-media.net` → `bborbe`. (If you never had that address, it's your Confluence/Jira login name.)
+- **No trailing slash on `url`.** Write `https://teamvault.seibert.tools`, not `…/`. (The CLI now strips a trailing slash defensively, but a stale config with `…tools/` was a common first-fetch failure — it produced a double-slash API path that 404s.)
 
 Override the location with `--teamvault-config <path>` or `export TEAMVAULT_CONFIG=<path>`. Every setting also has a flag (`--teamvault-url`, `--teamvault-user`, …) and env var (`TEAMVAULT_URL`, `TEAMVAULT_USER`, …); precedence is flag → env → config file.
 
-Password: prefer the Keychain over the config file. Run `teamvault-cli login` once — it verifies the password and stores it in the macOS Keychain, after which every command reads it automatically.
+Password: prefer the Keychain over the config file. Run `teamvault-cli login` once **in a plain terminal** (it prompts for the password interactively — never paste a secret into an AI session) — it verifies the password and stores it in the macOS Keychain, after which every command reads it automatically.
+
+New to the tool? `/teamvault-cli:setup` walks through install → config → login → verify interactively.
 
 ## Retrieving a secret
 


### PR DESCRIPTION
## What

Two onboarding-hardening changes, prompted by a colleague struggling to set up the CLI:

1. **New `/teamvault-cli:setup` command** (`commands/setup.md`) — guided first-time Seibert setup: Homebrew install → **interactive + non-interactive PATH check** (the Apple-Silicon `/opt/homebrew/bin` gotcha that silently breaks `.envrc`/direnv) → XDG config → login instruction → verify. It **configures + instructs + verifies but never runs `login` itself** — login prompts for the password interactively, and that value must never enter an AI session/transcript.

2. **Strip trailing slash from the base URL** (`fix`, TDD) — `Url.Normalize()` trims a trailing `/` (+ whitespace), applied in `NewRemoteConnector` **and** the Keychain read/write. A configured `https://teamvault.seibert.tools/` previously built `…//api/secrets/…` → 404 on first fetch; normalizing in both places also keeps the Keychain key consistent between `login` (write) and fetch (read). **Not** applied to the `Url` type globally — the `url` subcommand returns a secret's own stored URL and must stay verbatim.

## Why

The `user` field must be the **LDAP username** (not an email) and the URL must have **no trailing slash** — both undocumented traps. The skill/docs even showed the URL *with* a trailing slash. Fixed the CLI to be defensive and the docs to be explicit (LDAP hint: local part of the old `@seibert-media.net` address).

## Tests

- Unit: `Url.Normalize()` table + a ghttp connector test (trailing-slash URL → single-slash request path) + Keychain read/write normalize cases.
- Hermetic e2e: new `trailing-slash url resolves` case in `scripts/e2e.sh`.
- `make precommit` (159 specs) + `make e2e` (12 cases) green.

## Docs

- `skills/teamvault/SKILL.md` — Seibert-specific config (LDAP username + email hint, no trailing slash, login in a plain terminal), points at `/teamvault-cli:setup`.