### PR TITLE
genericize public docs — vendor-neutral placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- docs: keep the public repo vendor-neutral — replace company-specific examples (domain, email, username) in the `/teamvault-cli:setup` command, the `teamvault` skill, docs, a code comment, and test data with generic placeholders (`teamvault.example.com`, `<your-username>`). Company-specific onboarding lives in downstream skill repos. Also add a "multiple instances (work + personal)" section to the getting-started guide.
+
 ## v5.6.0
 
-- feat(cli): add the `/teamvault-cli:setup` Claude Code command — a guided first-time Seibert setup (Homebrew install, interactive+non-interactive PATH check, XDG config, login instruction, verify). It configures + instructs + verifies but never runs `login` itself, so the interactive password never enters an AI session.
-- fix(url): strip a trailing slash (and surrounding whitespace) from the base TeamVault URL via `Url.Normalize()`, applied in `NewRemoteConnector` and the Keychain read/write. A configured `https://teamvault.seibert.tools/` previously produced a double-slash API path (`…//api/secrets/…`) that 404'd on the first fetch; normalizing in both places also keeps the Keychain key consistent between `login` (write) and fetch (read). Added unit tests + a hermetic trailing-slash e2e case.
-- docs(skill): make the config guidance Seibert-specific — `user` is the LDAP username (hint: the local part of the old `@seibert-media.net` address, `bborbe@seibert-media.net` → `bborbe`), `url` has no trailing slash, and `login` runs in a plain terminal (never paste a secret into an AI session). Point new users at `/teamvault-cli:setup`.
+- feat(cli): add the `/teamvault-cli:setup` Claude Code command — a guided first-time setup (Homebrew install, interactive+non-interactive PATH check, XDG config, login instruction, verify). It configures + instructs + verifies but never runs `login` itself, so the interactive password never enters an AI session.
+- fix(url): strip a trailing slash (and surrounding whitespace) from the base TeamVault URL via `Url.Normalize()`, applied in `NewRemoteConnector` and the Keychain read/write. A configured base URL with a trailing slash (e.g. `https://teamvault.example.com/`) previously produced a double-slash API path (`…//api/secrets/…`) that 404'd on the first fetch; normalizing in both places also keeps the Keychain key consistent between `login` (write) and fetch (read). Added unit tests + a hermetic trailing-slash e2e case.
+- docs(skill): sharpen the config guidance — `user` is your TeamVault username (typically a directory/login name, not an email), `url` has no trailing slash, and `login` runs in a plain terminal (never paste a secret into an AI session). Point new users at `/teamvault-cli:setup`.
 
 ## v5.5.3
 

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,11 +1,11 @@
 ---
-description: Guided first-time setup of teamvault-cli for Seibert TeamVault (install, config, login hint, verify)
+description: Guided first-time setup of teamvault-cli (install, config, login hint, verify)
 allowed-tools: Bash(command -v:*), Bash(uname:*), Bash(brew:*), Bash(zsh:*), Bash(mkdir:*), Bash(teamvault-cli:*), Read, Write, AskUserQuestion
 ---
 
-# Set up teamvault-cli (Seibert)
+# Set up teamvault-cli
 
-Walk a new user through first-time setup of `teamvault-cli` against Seibert TeamVault, end to end. Optimized for the two things people get wrong: the **`user` must be the LDAP username** (not an email), and on macOS **Homebrew's bin must be on the PATH for non-interactive shells** (direnv / `.envrc` run there).
+Walk a new user through first-time setup of `teamvault-cli` against a TeamVault instance, end to end. Optimized for the two things people get wrong: the **`user` is usually your directory/login username** (not an email), and on macOS **Homebrew's bin must be on the PATH for non-interactive shells** (direnv / `.envrc` run there).
 
 **Never handle the password.** `teamvault-cli login` prompts for it interactively; that value must never enter this session or the transcript. This command configures + instructs + verifies — it does NOT run `login`.
 
@@ -58,15 +58,15 @@ echo -n "non-interactive shell:   "; zsh -c 'command -v teamvault-cli' 2>/dev/nu
 
 Determine the two values:
 
-- **URL** — Seibert is always `https://teamvault.seibert.tools` (**no trailing slash** — the CLI now strips one defensively, but write it clean).
-- **`user`** — the **LDAP username**, NOT an email. Hint to give the user: *it's the local part of your old `@seibert-media.net` address* — e.g. `bborbe@seibert-media.net` → `bborbe`. If they never had that address, it's their Confluence/Jira/LDAP login name. Ask via `AskUserQuestion` if unknown; do not guess.
+- **URL** — the TeamVault base URL (e.g. `https://teamvault.example.com`), **no trailing slash** — the CLI now strips one defensively, but write it clean. Ask the user for their instance URL.
+- **`user`** — the TeamVault username, typically your **directory/LDAP login name, NOT an email address** (some orgs derive it from your email's local part). Ask via `AskUserQuestion` if unknown; do not guess.
 
 Create the XDG-default dir (`mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/teamvault-cli"`), then write `config.json` there (substitute the LDAP username; never put a password in the file):
 
 ```json
 {
-    "url": "https://teamvault.seibert.tools",
-    "user": "<ldap-username>"
+    "url": "https://teamvault.example.com",
+    "user": "<your-username>"
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,8 @@ teamvault-cli --version
 
 ## 2. Configure
 
+> **In a Claude Code session**, the `/teamvault-cli:setup` command walks through install, config, and login interactively — the rest of this section is the manual equivalent.
+
 `teamvault-cli` needs to know your TeamVault URL and username. The password is best left out of the config file and stored in your macOS Keychain via `teamvault-cli login` (see step 3).
 
 Create the config file. With no flag or env var set, the tool reads the first that exists, XDG path first:
@@ -49,10 +51,15 @@ Create the config file. With no flag or env var set, the tool reads the first th
 
 ```json
 {
-  "url": "https://teamvault.your-company.example",
+  "url": "https://teamvault.example.com",
   "user": "your-teamvault-username"
 }
 ```
+
+Two easy-to-miss details:
+
+- **No trailing slash on `url`** — write `https://teamvault.example.com`, not `…/`. (Recent versions strip it defensively, but a trailing slash in an older config produced a double-slash API path that 404'd on the first fetch.)
+- **`user` is your TeamVault username, not an email** — typically your directory/login name (some orgs derive it from your email's local part).
 
 To use a different location, pass `--teamvault-config <path>` or export `TEAMVAULT_CONFIG=<path>` once (e.g. in your shell profile or a project `.envrc`) — both override the default lookup.
 
@@ -77,6 +84,24 @@ teamvault-cli login
 ```
 
 This prompts for your TeamVault password (input hidden), verifies it against the server, and stores it in your **macOS Keychain**. After that, you never pass `--teamvault-pass` again — every command reads the password from the Keychain automatically. (Keychain storage is macOS-only today; on other platforms, supply the password via `TEAMVAULT_PASS` or the config file.)
+
+### Multiple instances (e.g. work and personal)
+
+`teamvault-cli` handles more than one TeamVault at once. The Keychain stores each password keyed by the **instance URL**, so you `login` once per config and each resolves independently:
+
+```bash
+teamvault-cli login                                              # default instance (XDG config)
+teamvault-cli login --teamvault-config ~/.teamvault-personal.json   # a second instance, its own config
+```
+
+Then point each call at the config you want — or let the default apply:
+
+```bash
+teamvault-cli password --teamvault-key <KEY>                                                 # default instance
+teamvault-cli password --teamvault-config ~/.teamvault-personal.json --teamvault-key <KEY>   # second instance
+```
+
+The two configs must have **different URLs** — the Keychain key is the URL, so two configs sharing one URL would overwrite each other's stored password.
 
 ## 4. Read a secret
 

--- a/pkg/remote-connector.go
+++ b/pkg/remote-connector.go
@@ -37,7 +37,7 @@ func (u Url) String() string {
 // Normalize returns the Url with surrounding whitespace and trailing slashes
 // removed. TeamVault API paths are built as "<url>/api/secrets/...", so a base
 // URL that ends in a slash (e.g. the value copied from a browser,
-// "https://teamvault.seibert.tools/") would produce a double-slash path that
+// "https://teamvault.example.com/") would produce a double-slash path that
 // 404s. It is also the key the Keychain stores the password under, so login
 // (write) and fetch (read) must normalize identically or the lookup misses.
 func (u Url) Normalize() Url {

--- a/pkg/url_normalize_test.go
+++ b/pkg/url_normalize_test.go
@@ -26,23 +26,23 @@ var _ = Describe("Url.Normalize", func() {
 		},
 		Entry(
 			"already clean",
-			teamvault.Url("https://teamvault.seibert.tools"),
-			teamvault.Url("https://teamvault.seibert.tools"),
+			teamvault.Url("https://teamvault.example.com"),
+			teamvault.Url("https://teamvault.example.com"),
 		),
 		Entry(
 			"single trailing slash",
-			teamvault.Url("https://teamvault.seibert.tools/"),
-			teamvault.Url("https://teamvault.seibert.tools"),
+			teamvault.Url("https://teamvault.example.com/"),
+			teamvault.Url("https://teamvault.example.com"),
 		),
 		Entry(
 			"multiple trailing slashes",
-			teamvault.Url("https://teamvault.seibert.tools//"),
-			teamvault.Url("https://teamvault.seibert.tools"),
+			teamvault.Url("https://teamvault.example.com//"),
+			teamvault.Url("https://teamvault.example.com"),
 		),
 		Entry(
 			"surrounding whitespace",
-			teamvault.Url("  https://teamvault.seibert.tools/  "),
-			teamvault.Url("https://teamvault.seibert.tools"),
+			teamvault.Url("  https://teamvault.example.com/  "),
+			teamvault.Url("https://teamvault.example.com"),
 		),
 		Entry("empty stays empty", teamvault.Url(""), teamvault.Url("")),
 	)
@@ -57,7 +57,7 @@ var _ = Describe("RemoteConnector with trailing-slash URL", func() {
 		ctx = context.Background()
 		server = ghttp.NewServer()
 		// Build the connector with a URL that ends in a slash — the value a
-		// Seibert user copies from the browser (https://teamvault.seibert.tools/).
+		// user copies from the browser (https://teamvault.example.com/).
 		// Without normalization this produces a double-slash path that 404s.
 		remoteConnector = teamvault.NewRemoteConnector(
 			libhttp.CreateDefaultHttpClient(),

--- a/skills/teamvault/SKILL.md
+++ b/skills/teamvault/SKILL.md
@@ -31,16 +31,16 @@ curl -sSL "https://github.com/Seibert-Data/teamvault-cli/releases/latest/downloa
 go install github.com/Seibert-Data/teamvault-cli/v5@latest   # installs to $(go env GOPATH)/bin
 ```
 
-Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy). At **Seibert** the file is:
+Config: `teamvault-cli` needs a URL + username. With no flag/env set, it reads the first that exists — `~/.config/teamvault-cli/config.json` (XDG, honors `$XDG_CONFIG_HOME`), then `~/.teamvault.json` (legacy):
 
 ```json
-{ "url": "https://teamvault.seibert.tools", "user": "<your-ldap-username>" }
+{ "url": "https://teamvault.example.com", "user": "<your-username>" }
 ```
 
 Two things people get wrong here:
 
-- **`user` is your LDAP username, not an email.** It's the local part of your old `@seibert-media.net` address — e.g. `bborbe@seibert-media.net` → `bborbe`. (If you never had that address, it's your Confluence/Jira login name.)
-- **No trailing slash on `url`.** Write `https://teamvault.seibert.tools`, not `…/`. (The CLI now strips a trailing slash defensively, but a stale config with `…tools/` was a common first-fetch failure — it produced a double-slash API path that 404s.)
+- **`user` is your TeamVault username, not an email** — typically your directory/LDAP login name (some orgs derive it from your email's local part). Ask if unsure; don't guess.
+- **No trailing slash on `url`.** Write `https://teamvault.example.com`, not `…/`. (The CLI now strips a trailing slash defensively, but a stale config with a trailing slash was a common first-fetch failure — it produced a double-slash API path that 404s.)
 
 Override the location with `--teamvault-config <path>` or `export TEAMVAULT_CONFIG=<path>`. Every setting also has a flag (`--teamvault-url`, `--teamvault-user`, …) and env var (`TEAMVAULT_URL`, `TEAMVAULT_USER`, …); precedence is flag → env → config file.
 


### PR DESCRIPTION
## What

Keep the **public** repo vendor-neutral. Replace company-specific examples (TeamVault domain, `@…` email hint, personal username) in the setup command, skill, docs, a code comment, and test data with generic placeholders (`teamvault.example.com`, `<your-username>`).

## Why

This is a public open-source repo. Company-specific onboarding (real instance URL, email→username convention) belongs in downstream/internal skill repos that overlay the generic placeholders — not in the shipped tool.

## Changes

- `commands/setup.md` — drop "(Seibert)" branding + domain/email specifics → generic guided setup.
- `skills/teamvault/SKILL.md` — generic config guidance (username-not-email stated generically, no trailing slash).
- `docs/getting-started.md` — generic placeholder; **added a "Multiple instances (work + personal)" section**; pointer to `/teamvault-cli:setup`.
- `pkg/remote-connector.go` + `pkg/url_normalize_test.go` — example URL in a comment + test data.
- `CHANGELOG.md` — genericize the v5.6.0 wording + Unreleased entry.

Note: `Seibert-Data` org / `seibert-data` Homebrew tap in install paths are the actual public distribution and are kept. `specs/completed/001` still has company specifics + real lookup keys (pre-existing) — flagged for a separate redaction.

Docs/test-data only. `make precommit` + `make e2e` (13 cases) green.