### PR TITLE
feat(cli): positional key, --json output, and info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- feat(cli): accept the TeamVault key as a positional argument on `password`/`username`/`url`/`file` (e.g. `teamvault-cli password AbC123`); `--teamvault-key` is no longer required and still works for backward compatibility. Add a `--json` flag to those four commands for keyed JSON output (e.g. `{"password":"…"}`), default raw-value output unchanged. Add a new `info` subcommand (`teamvault-cli info <KEY>`) that fetches username/url/password/file in one call and prints an aligned table, or a single JSON object with `--json`.
+
 ## v5.6.1
 
 - docs: keep the public repo vendor-neutral — replace company-specific examples (domain, email, username) in the `/teamvault-cli:setup` command, the `teamvault` skill, docs, a code comment, and test data with generic placeholders (`teamvault.example.com`, `<your-username>`). Company-specific onboarding lives in downstream skill repos. Also add a "multiple instances (work + personal)" section to the getting-started guide.

--- a/README.md
+++ b/README.md
@@ -76,22 +76,45 @@ The secret **key** is the alphanumeric ID from the TeamVault web-UI URL (e.g. `�
 
 ## Use in shell scripts
 
-Reads print the raw value with **no trailing newline**, so they compose directly in command substitution:
+Reads print the raw value with **no trailing newline**, so they compose directly in command substitution. The key can be given as a positional argument (recommended) or via `--teamvault-key` (still supported):
 
 ```bash
 # Inject a secret into a process's environment
-export DB_PASSWORD="$(teamvault-cli password --teamvault-key AbC123)"
+export DB_PASSWORD="$(teamvault-cli password AbC123)"
 
 # Basic-auth for an API call
-curl -u "$(teamvault-cli username --teamvault-key AbC123):$(teamvault-cli password --teamvault-key AbC123)" \
+curl -u "$(teamvault-cli username AbC123):$(teamvault-cli password AbC123)" \
   https://api.internal/…
+
+# --teamvault-key still works
+export DB_PASSWORD="$(teamvault-cli password --teamvault-key AbC123)"
 ```
 
 With [direnv](https://direnv.net), put the lookups in `.envrc` so a repo's secrets load on `cd`:
 
 ```bash
 # .envrc
-export DB_PASSWORD="$(teamvault-cli password --teamvault-key AbC123)"
+export DB_PASSWORD="$(teamvault-cli password AbC123)"
+```
+
+Add `--json` to any of `password`/`username`/`url`/`file` for a keyed JSON object instead of the raw value — useful when piping into `jq` or another JSON-aware tool:
+
+```bash
+teamvault-cli password AbC123 --json
+# {"password":"s3cr3t"}
+```
+
+Use `info` to fetch username, url, password, and file in a single call — an aligned table by default, or one JSON object with `--json`:
+
+```bash
+teamvault-cli info AbC123
+# username: alice
+# url:      https://example.com
+# password: s3cr3t
+# file:
+
+teamvault-cli info AbC123 --json
+# {"file":"","password":"s3cr3t","url":"https://example.com","username":"alice"}
 ```
 
 ## Use in deployments (config templating)
@@ -135,12 +158,15 @@ Have the agent call `teamvault-cli` for credentials instead of embedding secrets
 | Command | Purpose |
 |---------|---------|
 | `teamvault-cli login` | verify credentials and store the password in the macOS Keychain |
-| `teamvault-cli password --teamvault-key <KEY>` | print a secret's password |
-| `teamvault-cli username --teamvault-key <KEY>` | print a secret's username |
-| `teamvault-cli url --teamvault-key <KEY>` | print a secret's URL |
-| `teamvault-cli file --teamvault-key <KEY>` | print a secret's file contents |
+| `teamvault-cli password <KEY>` | print a secret's password |
+| `teamvault-cli username <KEY>` | print a secret's username |
+| `teamvault-cli url <KEY>` | print a secret's URL |
+| `teamvault-cli file <KEY>` | print a secret's file contents |
+| `teamvault-cli info <KEY>` | print username, url, password, and file together |
 | `teamvault-cli config parse` | render a template from stdin to stdout |
 | `teamvault-cli config generate --source-dir <DIR> --target-dir <DIR>` | render a directory of templates |
+
+Add `--json` to `password`/`username`/`url`/`file`/`info` for JSON output. The key may also be given via `--teamvault-key <KEY>` instead of positionally (backward compatible).
 
 Run `teamvault-cli <command> --help` for all flags. Full walkthrough (config, env vars, direnv, agents): **[docs/getting-started.md](docs/getting-started.md)**.
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -164,6 +165,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		sf,
 		"password",
 		"Retrieve a password from TeamVault",
+		"password",
 		"get password failed",
 		func(ctx context.Context, conn teamvault.Connector, key teamvault.Key) (fmt.Stringer, error) {
 			return conn.Password(ctx, key)
@@ -174,6 +176,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		sf,
 		"username",
 		"Retrieve a username from TeamVault",
+		"username",
 		"get user failed",
 		func(ctx context.Context, conn teamvault.Connector, key teamvault.Key) (fmt.Stringer, error) {
 			return conn.User(ctx, key)
@@ -184,6 +187,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		sf,
 		"url",
 		"Retrieve a URL from TeamVault",
+		"url",
 		"get url failed",
 		func(ctx context.Context, conn teamvault.Connector, key teamvault.Key) (fmt.Stringer, error) {
 			return conn.Url(ctx, key)
@@ -194,11 +198,13 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 		sf,
 		"file",
 		"Retrieve a file from TeamVault",
+		"file",
 		"get file failed",
 		func(ctx context.Context, conn teamvault.Connector, key teamvault.Key) (fmt.Stringer, error) {
 			return conn.File(ctx, key)
 		},
 	))
+	rootCmd.AddCommand(createInfoCommand(ctx, sf))
 	rootCmd.AddCommand(createConfigCommand(ctx, sf))
 
 	return rootCmd
@@ -209,46 +215,179 @@ func envBool(name string) bool {
 	return os.Getenv(name) == "true"
 }
 
+// resolveKey resolves the TeamVault key from a positional argument or the
+// --teamvault-key flag, positional taking precedence. It returns an error
+// naming both forms when neither is given, since the flag is no longer
+// required and cobra can't enforce "one of" on its own.
+func resolveKey(cmd *cobra.Command, args []string) (teamvault.Key, error) {
+	if len(args) > 0 && args[0] != "" {
+		return teamvault.Key(args[0]), nil
+	}
+	flagKey, _ := cmd.Flags().GetString("teamvault-key")
+	if flagKey != "" {
+		return teamvault.Key(flagKey), nil
+	}
+	return "", errors.Errorf(
+		cmd.Context(),
+		"teamvault key required: pass it as a positional argument or via --teamvault-key",
+	)
+}
+
 // createSecretCommand builds a secret-reader subcommand. The four secret
 // readers (password/username/url/file) differ only in their Use/Short strings,
-// the connector method invoked, and the error message; this helper captures the
-// shared wiring (required --teamvault-key, buildConnector, writeSecret).
+// the JSON field name, the connector method invoked, and the error message;
+// this helper captures the shared wiring (positional/--teamvault-key
+// resolution, buildConnector, writeSecret).
 func createSecretCommand(
 	ctx context.Context,
 	sf *sharedFlags,
-	use, short, errMsg string,
+	use, short, jsonField, errMsg string,
 	fetch func(context.Context, teamvault.Connector, teamvault.Key) (fmt.Stringer, error),
 ) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   use + " [key]",
 		Short: short,
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			key, _ := cmd.Flags().GetString("teamvault-key")
+			key, err := resolveKey(cmd, args)
+			if err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
 			conn, err := sf.buildConnector(ctx)
 			if err != nil {
 				return err
 			}
-			result, err := fetch(ctx, conn, teamvault.Key(key))
+			result, err := fetch(ctx, conn, key)
 			if err != nil {
 				return errors.Wrap(ctx, err, errMsg)
 			}
-			return writeSecret(ctx, cmd.OutOrStdout(), result)
+			return writeSecret(ctx, cmd.OutOrStdout(), jsonField, result, asJSON)
 		},
 	}
 
 	var key string
-	cmd.Flags().StringVar(&key, "teamvault-key", "", "teamvault key")
-	_ = cmd.MarkFlagRequired("teamvault-key")
+	cmd.Flags().
+		StringVar(&key, "teamvault-key", "", "teamvault key (alternative to positional argument)")
+	cmd.Flags().
+		Bool("json", false, `print output as a JSON object (e.g. {"`+jsonField+`":"<value>"})`)
 
 	return cmd
 }
 
-// writeSecret writes the secret value to the given writer with no trailing newline.
-// This ensures curl -u style basic-auth usage works correctly.
-func writeSecret(ctx context.Context, out io.Writer, value fmt.Stringer) error {
-	if _, err := fmt.Fprintf(out, "%v", value); err != nil {
+// writeSecret writes the secret value to the given writer. In the default
+// mode it writes the raw value with no trailing newline, so curl -u style
+// basic-auth usage composes directly in command substitution. In --json mode
+// it writes a single-key JSON object ({"<field>":"<value>"}) with a trailing
+// newline.
+func writeSecret(
+	ctx context.Context,
+	out io.Writer,
+	field string,
+	value fmt.Stringer,
+	asJSON bool,
+) error {
+	if !asJSON {
+		if _, err := fmt.Fprintf(out, "%v", value); err != nil {
+			return errors.Wrapf(ctx, err, "write secret failed")
+		}
+		return nil
+	}
+	encoded, err := json.Marshal(map[string]string{field: value.String()})
+	if err != nil {
+		return errors.Wrapf(ctx, err, "marshal json failed")
+	}
+	if _, err := fmt.Fprintf(out, "%s\n", encoded); err != nil {
 		return errors.Wrapf(ctx, err, "write secret failed")
+	}
+	return nil
+}
+
+// createInfoCommand builds the `info` subcommand, which fetches and prints
+// all four fields (username, url, password, file) for a key in one call.
+// Missing/empty fields print empty rather than erroring, since not every
+// TeamVault secret populates every field.
+func createInfoCommand(ctx context.Context, sf *sharedFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info [key]",
+		Short: "Retrieve username, url, password, and file for a TeamVault secret",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := resolveKey(cmd, args)
+			if err != nil {
+				return err
+			}
+			asJSON, _ := cmd.Flags().GetBool("json")
+			conn, err := sf.buildConnector(ctx)
+			if err != nil {
+				return err
+			}
+
+			username, err := conn.User(ctx, key)
+			if err != nil {
+				return errors.Wrap(ctx, err, "get user failed")
+			}
+			url, err := conn.Url(ctx, key)
+			if err != nil {
+				return errors.Wrap(ctx, err, "get url failed")
+			}
+			password, err := conn.Password(ctx, key)
+			if err != nil {
+				return errors.Wrap(ctx, err, "get password failed")
+			}
+			file, err := conn.File(ctx, key)
+			if err != nil {
+				return errors.Wrap(ctx, err, "get file failed")
+			}
+
+			return writeInfo(ctx, cmd.OutOrStdout(), username, url, password, file, asJSON)
+		},
+	}
+
+	var key string
+	cmd.Flags().
+		StringVar(&key, "teamvault-key", "", "teamvault key (alternative to positional argument)")
+	cmd.Flags().Bool("json", false, "print output as a JSON object")
+
+	return cmd
+}
+
+// writeInfo writes the four secret fields to the given writer. In the
+// default mode it writes an aligned "key: value" table; in --json mode it
+// writes a single JSON object with all four fields.
+func writeInfo(
+	ctx context.Context,
+	out io.Writer,
+	username teamvault.User,
+	url teamvault.Url,
+	password teamvault.Password,
+	file teamvault.File,
+	asJSON bool,
+) error {
+	if !asJSON {
+		if _, err := fmt.Fprintf(
+			out,
+			"username: %s\nurl:      %s\npassword: %s\nfile:     %s\n",
+			username,
+			url,
+			password,
+			file,
+		); err != nil {
+			return errors.Wrapf(ctx, err, "write info failed")
+		}
+		return nil
+	}
+	encoded, err := json.Marshal(map[string]string{
+		"username": username.String(),
+		"url":      url.String(),
+		"password": password.String(),
+		"file":     file.String(),
+	})
+	if err != nil {
+		return errors.Wrapf(ctx, err, "marshal json failed")
+	}
+	if _, err := fmt.Fprintf(out, "%s\n", encoded); err != nil {
+		return errors.Wrapf(ctx, err, "write info failed")
 	}
 	return nil
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -127,19 +127,180 @@ var _ = Describe("CLI", func() {
 			Expect(output).To(ContainSubstring("--teamvault-timeout"))
 			Expect(output).To(ContainSubstring("--cache"))
 			Expect(output).To(ContainSubstring("--teamvault-key"))
+			Expect(output).To(ContainSubstring("--json"))
 		})
 	})
 
-	Describe("missing --teamvault-key", func() {
-		It("returns required flag error without calling connector", func() {
+	Describe("missing key", func() {
+		It(
+			"returns a clear error without calling connector when neither positional nor flag is given",
+			func() {
+				var errBuf bytes.Buffer
+				cmd := cli.NewRootCommand(ctx)
+				cmd.SetArgs([]string{"password"})
+				cmd.SetOut(&bytes.Buffer{})
+				cmd.SetErr(&errBuf)
+				err := cmd.Execute()
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("teamvault key required"))
+			},
+		)
+	})
+
+	Describe("positional key", func() {
+		It("password accepts the key as a positional argument", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"password", "testkey"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).NotTo(BeEmpty())
+		})
+
+		It("password still accepts --teamvault-key (backward compat)", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"password", "--teamvault-key", "testkey"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).NotTo(BeEmpty())
+		})
+
+		It("positional argument takes precedence over --teamvault-key when both given", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"password", "positional-key", "--teamvault-key", "flag-key"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).NotTo(BeEmpty())
+		})
+
+		It("rejects more than one positional argument", func() {
 			var errBuf bytes.Buffer
 			cmd := cli.NewRootCommand(ctx)
-			cmd.SetArgs([]string{"password"})
+			cmd.SetArgs([]string{"password", "key1", "key2"})
 			cmd.SetOut(&bytes.Buffer{})
 			cmd.SetErr(&errBuf)
 			err := cmd.Execute()
-			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(ContainSubstring(`required flag(s) "teamvault-key" not set`))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("--json output", func() {
+		It("password --json prints a keyed JSON object", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"password", "testkey", "--json"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(buf.String())).To(MatchRegexp(`^\{"password":".*"\}$`))
+		})
+
+		It("username --json prints a keyed JSON object", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"username", "testkey", "--json"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.TrimSpace(buf.String())).To(MatchRegexp(`^\{"username":".*"\}$`))
+		})
+	})
+
+	Describe("info command", func() {
+		It("prints an aligned key: value table by default", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"info", "testkey"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			output := buf.String()
+			Expect(output).To(ContainSubstring("username:"))
+			Expect(output).To(ContainSubstring("url:"))
+			Expect(output).To(ContainSubstring("password:"))
+			Expect(output).To(ContainSubstring("file:"))
+		})
+
+		It("prints a single JSON object with --json", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"info", "testkey", "--json"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			output := strings.TrimSpace(buf.String())
+			Expect(output).To(ContainSubstring(`"username"`))
+			Expect(output).To(ContainSubstring(`"url"`))
+			Expect(output).To(ContainSubstring(`"password"`))
+			Expect(output).To(ContainSubstring(`"file"`))
+			Expect(output).To(HavePrefix("{"))
+			Expect(output).To(HaveSuffix("}"))
+		})
+
+		It("supports --teamvault-key for backward compat", func() {
+			os.Setenv("STAGING", "true")
+			DeferCleanup(func() {
+				os.Unsetenv("STAGING")
+			})
+			var buf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"info", "--teamvault-key", "testkey"})
+			cmd.SetOut(&buf)
+			cmd.SetErr(&bytes.Buffer{})
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).NotTo(BeEmpty())
+		})
+
+		It("returns error when neither positional nor flag key is given", func() {
+			var errBuf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"info"})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&errBuf)
+			err := cmd.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("teamvault key required"))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- `password`/`username`/`url`/`file` accept the TeamVault key as a positional argument (`teamvault-cli password ABC`); `--teamvault-key` is no longer required but still works (backward compatible).
- Add `--json` to those four commands for keyed JSON output (e.g. `{"password":"…"}`); default raw-value output (no trailing newline) unchanged.
- Add a new `info <KEY>` subcommand that fetches username/url/password/file in one call — aligned table by default, single JSON object with `--json`.

## Test plan
- [x] `make precommit` green (fmt, generate, tests, lint, security scans)
- [x] New Ginkgo tests: positional key, `--teamvault-key` backward compat, precedence, missing-key error, `--json` shape, `info` table + json
- [x] Manual smoke test against `--staging` connector for all new flags/command