### PR TITLE
add htpasswd subcommand deriving user:bcrypt from a secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- feat(cli): add `htpasswd <KEY>` subcommand that prints an htpasswd-format credential (`user:$2...` bcrypt) built from a TeamVault secret's username + password, for secret-free htpasswd generation at deploy time (e.g. `--set-string secrets.htpasswd=$(teamvault-cli htpasswd <KEY>)`). Reuses the existing `HtpasswdGenerator` (same bcrypt path as the `teamvaultHtpasswd` config template func).
 - feat(cli): `search` now prints an aligned `KEY  NAME` table by default, follows TeamVault pagination so results are not truncated to the first page, adds `--limit N` to cap results and `--keys-only` for bare-key-per-line scripting output. `--json` now emits an array of `{key,name,username,url}` objects instead of an array of key strings (breaking output-shape change).
 
 ## v5.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- test(e2e): add scenario 009 covering `htpasswd` end-to-end against fakevault (seeded fixture + a freshly created secret)
 - feat(cli): add `htpasswd <KEY>` subcommand that prints an htpasswd-format credential (`user:$2...` bcrypt) built from a TeamVault secret's username + password, for secret-free htpasswd generation at deploy time (e.g. `--set-string secrets.htpasswd=$(teamvault-cli htpasswd <KEY>)`). Reuses the existing `HtpasswdGenerator` (same bcrypt path as the `teamvaultHtpasswd` config template func).
 - feat(cli): `search` now prints an aligned `KEY  NAME` table by default, follows TeamVault pagination so results are not truncated to the first page, adds `--limit N` to cap results and `--keys-only` for bare-key-per-line scripting output. `--json` now emits an array of `{key,name,username,url}` objects instead of an array of key strings (breaking output-shape change).
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,17 @@ Pipe rendered output straight to `kubectl` if you'd rather not write secrets to 
 teamvault-cli config parse < templates/db-secret.yaml | kubectl apply -f -
 ```
 
+For basic-auth ingresses that need an htpasswd secret, `htpasswd <KEY>` derives the `user:bcrypt` line from a secret's username + password at deploy time — no pre-computed hash in git:
+
+```bash
+# append to an htpasswd file
+teamvault-cli htpasswd AbC123 >> auth/htpasswd
+
+# or inline into a Helm value
+helm upgrade registry ./chart \
+  --set-string secrets.htpasswd="$(teamvault-cli htpasswd AbC123)"
+```
+
 ## Use with an AI agent
 
 Have the agent call `teamvault-cli` for credentials instead of embedding secrets in prompts or code — the value is resolved just-in-time and never written to the conversation or the repo. The Claude Code plugin's `/teamvault` skill enforces this. See the [getting-started guide](docs/getting-started.md#6-use-it-with-an-ai-agent-claude-code).
@@ -177,6 +188,7 @@ Have the agent call `teamvault-cli` for credentials instead of embedding secrets
 | `teamvault-cli file <KEY>` | print a secret's file contents |
 | `teamvault-cli info <KEY>` | print username, url, password, and file together |
 | `teamvault-cli search <QUERY>` | search secrets by name and print matching keys |
+| `teamvault-cli htpasswd <KEY>` | print an htpasswd line (`user:bcrypt`) built from the secret's username + password |
 | `teamvault-cli config parse` | render a template from stdin to stdout |
 | `teamvault-cli config generate --source-dir <DIR> --target-dir <DIR>` | render a directory of templates |
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/crypto v0.54.0
 	golang.org/x/term v0.45.0
 )
 
@@ -46,7 +47,6 @@ require (
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -209,6 +209,7 @@ func NewRootCommand(ctx context.Context) *cobra.Command {
 	rootCmd.AddCommand(createCreateCommand(ctx, sf))
 	rootCmd.AddCommand(createUpdateCommand(ctx, sf))
 	rootCmd.AddCommand(createSearchCommand(ctx, sf))
+	rootCmd.AddCommand(createHtpasswdCommand(ctx, sf))
 
 	return rootCmd
 }

--- a/pkg/cli/htpasswd.go
+++ b/pkg/cli/htpasswd.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/bborbe/errors"
+	"github.com/spf13/cobra"
+
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+)
+
+// createHtpasswdCommand builds the `htpasswd` subcommand, which prints an
+// htpasswd-format credential (user:$2y$... bcrypt) built from a TeamVault
+// entry's username + password. This enables secret-free htpasswd generation at
+// deploy time, e.g. `--set-string secrets.htpasswd=$(teamvault-cli htpasswd <key>)`,
+// so no pre-computed hash needs to live in git.
+func createHtpasswdCommand(ctx context.Context, sf *SharedFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "htpasswd [key]",
+		Short: "Print an htpasswd-format credential (user:bcrypt) for a TeamVault secret",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := resolveKey(cmd, args)
+			if err != nil {
+				return err
+			}
+			conn, err := newConnector(sf)(ctx)
+			if err != nil {
+				return errors.Wrap(ctx, err, "create connector failed")
+			}
+			// Reuse the shared HtpasswdGenerator (same bcrypt logic the
+			// teamvaultHtpasswd config template func uses) — no duplicated hashing.
+			content, err := teamvault.NewHtpasswdGenerator(conn).Generate(ctx, key)
+			if err != nil {
+				return errors.Wrap(ctx, err, "generate htpasswd failed")
+			}
+			// Write the generator's bytes verbatim: they are htpasswd-file
+			// format (`user:$2y$...\n`), correct to append to an htpasswd file,
+			// and the trailing newline is stripped by `$(...)` command
+			// substitution for the --set-string use.
+			if _, err := cmd.OutOrStdout().Write(content); err != nil {
+				return errors.Wrapf(ctx, err, "write htpasswd failed")
+			}
+			return nil
+		},
+	}
+
+	var key string
+	cmd.Flags().
+		StringVar(&key, "teamvault-key", "", "teamvault key (alternative to positional argument)")
+
+	return cmd
+}

--- a/pkg/cli/htpasswd_test.go
+++ b/pkg/cli/htpasswd_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2016-2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	stderrors "errors"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"golang.org/x/crypto/bcrypt"
+
+	teamvault "github.com/Seibert-Data/teamvault-cli/v5/pkg"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/cli"
+	"github.com/Seibert-Data/teamvault-cli/v5/pkg/mocks"
+)
+
+var _ = Describe("htpasswd", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		os.Setenv("STAGING", "true")
+		os.Unsetenv("TEAMVAULT_URL")
+		os.Unsetenv("TEAMVAULT_USER")
+		os.Unsetenv("TEAMVAULT_PASS")
+		os.Unsetenv("TEAMVAULT_CONFIG")
+		os.Unsetenv("TEAMVAULT_TIMEOUT")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("STAGING")
+	})
+
+	Describe("command registration", func() {
+		It("NewRootCommand includes the htpasswd subcommand", func() {
+			rootCmd := cli.NewRootCommand(ctx)
+			subNames := make([]string, len(rootCmd.Commands()))
+			for i, c := range rootCmd.Commands() {
+				subNames[i] = c.Name()
+			}
+			Expect(subNames).To(ContainElement("htpasswd"))
+		})
+	})
+
+	Describe("valid key", func() {
+		It("prints a user:bcrypt line that verifies against the password", func() {
+			fakeConn := &mocks.Connector{}
+			fakeConn.UserReturns(teamvault.User("myuser"), nil)
+			fakeConn.PasswordReturns(teamvault.Password("s3cret"), nil)
+
+			var outBuf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"htpasswd", "ABC123"})
+			cmd.SetOut(&outBuf)
+			cmd.SetErr(&bytes.Buffer{})
+
+			cli.SetNewConnectorForTest(
+				func(sf *cli.SharedFlags) func(context.Context) (teamvault.Connector, error) {
+					return func(ctx context.Context) (teamvault.Connector, error) {
+						return fakeConn, nil
+					}
+				},
+			)
+			defer cli.ResetNewConnectorForTest()
+
+			err := cmd.Execute()
+			Expect(err).To(BeNil())
+
+			line := strings.TrimRight(outBuf.String(), "\n")
+			Expect(line).To(HavePrefix("myuser:"))
+			user, hash, found := strings.Cut(line, ":")
+			Expect(found).To(BeTrue())
+			Expect(user).To(Equal("myuser"))
+			Expect(hash).To(HavePrefix("$2"))
+			// The emitted hash is a real bcrypt hash of the secret password.
+			Expect(bcrypt.CompareHashAndPassword([]byte(hash), []byte("s3cret"))).To(Succeed())
+			// Key is resolved and passed through to the connector.
+			Expect(fakeConn.PasswordCallCount()).To(Equal(1))
+			_, pwKey := fakeConn.PasswordArgsForCall(0)
+			Expect(pwKey).To(Equal(teamvault.Key("ABC123")))
+		})
+	})
+
+	Describe("connector error", func() {
+		It("returns an error when the password lookup fails", func() {
+			fakeConn := &mocks.Connector{}
+			fakeConn.PasswordReturns(teamvault.Password(""), stderrors.New("boom"))
+
+			var errBuf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"htpasswd", "ABC123"})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&errBuf)
+
+			cli.SetNewConnectorForTest(
+				func(sf *cli.SharedFlags) func(context.Context) (teamvault.Connector, error) {
+					return func(ctx context.Context) (teamvault.Connector, error) {
+						return fakeConn, nil
+					}
+				},
+			)
+			defer cli.ResetNewConnectorForTest()
+
+			err := cmd.Execute()
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("generate htpasswd failed"))
+		})
+	})
+
+	Describe("missing key", func() {
+		It("returns an error when no key is provided", func() {
+			var errBuf bytes.Buffer
+			cmd := cli.NewRootCommand(ctx)
+			cmd.SetArgs([]string{"htpasswd"})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&errBuf)
+
+			err := cmd.Execute()
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("teamvault key required"))
+		})
+	})
+})

--- a/pkg/cli/htpasswd_test.go
+++ b/pkg/cli/htpasswd_test.go
@@ -84,6 +84,9 @@ var _ = Describe("htpasswd", func() {
 			Expect(fakeConn.PasswordCallCount()).To(Equal(1))
 			_, pwKey := fakeConn.PasswordArgsForCall(0)
 			Expect(pwKey).To(Equal(teamvault.Key("ABC123")))
+			Expect(fakeConn.UserCallCount()).To(Equal(1))
+			_, userKey := fakeConn.UserArgsForCall(0)
+			Expect(userKey).To(Equal(teamvault.Key("ABC123")))
 		})
 	})
 
@@ -91,6 +94,10 @@ var _ = Describe("htpasswd", func() {
 		It("returns an error when the password lookup fails", func() {
 			fakeConn := &mocks.Connector{}
 			fakeConn.PasswordReturns(teamvault.Password(""), stderrors.New("boom"))
+			// Stub User too so the test stays correct if Generate ever reorders
+			// its User/Password calls (otherwise a zero-value User + nil error
+			// would silently mask the error path).
+			fakeConn.UserReturns(teamvault.User(""), nil)
 
 			var errBuf bytes.Buffer
 			cmd := cli.NewRootCommand(ctx)

--- a/scenarios/009-htpasswd-e2e.md
+++ b/scenarios/009-htpasswd-e2e.md
@@ -1,0 +1,47 @@
+---
+status: active
+---
+
+# Scenario 009: htpasswd subcommand via the fake TeamVault server
+
+Validates the `htpasswd <KEY>` subcommand end-to-end against `cmd/fakevault`. Exercises the real HTTP connector reading a secret's username + password and the shared `HtpasswdGenerator` bcrypt path — producing a deploy-ready `user:$2...` htpasswd line — against a live (fake) server, which the unit tests (mocked connector) do not.
+
+Setup/assert helpers live in `scenarios/helper/lib.sh` (same convention as scenarios 007/008). CI runs the whole thing via `make e2e`; the fastest local path is also `make e2e`.
+
+Covered cases: `htpasswd` on a seeded fixture (`demo`) prints `<username>:<bcrypt>` as a single line; the same works on a freshly `create`d secret, confirming the read → hash path over real HTTP (not just the mocked-connector unit tests).
+
+## Setup
+
+```bash
+source scenarios/helper/lib.sh
+build_binaries      # builds teamvault-cli + fakevault to a temp dir, sets $TV
+start_fakevault     # starts the server, writes a temp config, exports TEAMVAULT_CONFIG
+```
+
+- [ ] `$TV` exists; `fakevault` is listening (`$FV_URL` non-empty); the `demo` fixture resolves
+
+## Action + Expected
+
+```bash
+# Seeded fixture: demo -> username demo-user / password demo-pass-123.
+HTP_DEMO="$("$TV" htpasswd --teamvault-key demo)"
+assert_contains "htpasswd carries the username prefix" "demo-user:" "$HTP_DEMO"
+assert_contains "htpasswd emits a bcrypt hash"         '$2'         "$HTP_DEMO"
+assert_eq "htpasswd is a single user:bcrypt line" "1" \
+	"$(printf '%s\n' "$HTP_DEMO" | grep -c '^demo-user:\$2')"
+
+# Freshly created secret: htpasswd reads username+password back over real HTTP
+# (same write path as scenario 008) and hashes them.
+HTP_KEY="$(printf 'reg-pw' | "$TV" create --name htpasswd-e2e-secret --username reg-user --password-stdin)"
+HTP_NEW="$("$TV" htpasswd --teamvault-key "$HTP_KEY")"
+assert_contains "htpasswd of a created secret carries its username" "reg-user:" "$HTP_NEW"
+assert_contains "htpasswd of a created secret is bcrypt"            '$2'        "$HTP_NEW"
+
+scenario_done   # prints "e2e: PASS" and exits non-zero if any assertion failed
+```
+
+- [ ] All assertions print `ok:` and `scenario_done` reports `e2e: PASS`
+
+## Cleanup
+
+`scenarios/helper/lib.sh` installs an EXIT trap that kills `fakevault` and removes `$WORK_DIR` — no manual cleanup needed.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -53,10 +53,6 @@ assert_contains "auth failure suggests login" "teamvault-cli login" \
 # Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
 assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
 
-# htpasswd — derives a user:bcrypt line from the secret's username + password.
-assert_contains "htpasswd user prefix" "demo-user:" "$("$TV" htpasswd --teamvault-key demo)"
-assert_contains "htpasswd is bcrypt"   '$2'         "$("$TV" htpasswd --teamvault-key demo)"
-
 # trailing-slash URL — a config whose url ends in "/" must still resolve (the CLI
 # normalizes it; without that, "<url>//api/secrets/…" 404s). This is the exact
 # value a user copies from the browser.
@@ -91,5 +87,22 @@ assert_eq "read back updated password" "updated-secret-pw" "$("$TV" password --t
 "$TV" update "$NEW_KEY" --username wse-user-renamed >/dev/null
 assert_eq "read back updated username"                  "wse-user-renamed"  "$("$TV" username --teamvault-key "$NEW_KEY")"
 assert_eq "password unchanged by metadata-only update" "updated-secret-pw" "$("$TV" password --teamvault-key "$NEW_KEY")"
+
+# --- Scenario 009: htpasswd derives a user:bcrypt line from a secret ---------
+
+# Seeded fixture (demo -> username demo-user / password demo-pass-123): the
+# htpasswd line carries the username verbatim and a bcrypt hash ($2...).
+HTP_DEMO="$("$TV" htpasswd --teamvault-key demo)"
+assert_contains "htpasswd carries the username prefix" "demo-user:" "$HTP_DEMO"
+assert_contains "htpasswd emits a bcrypt hash"         '$2'         "$HTP_DEMO"
+assert_eq "htpasswd is a single user:bcrypt line" "1" \
+	"$(printf '%s\n' "$HTP_DEMO" | grep -c '^demo-user:\$2')"
+
+# Freshly created secret: htpasswd reads username+password back over real HTTP
+# (same write path as scenario 008) and hashes them.
+HTP_KEY="$(printf 'reg-pw' | "$TV" create --name htpasswd-e2e-secret --username reg-user --password-stdin)"
+HTP_NEW="$("$TV" htpasswd --teamvault-key "$HTP_KEY")"
+assert_contains "htpasswd of a created secret carries its username" "reg-user:" "$HTP_NEW"
+assert_contains "htpasswd of a created secret is bcrypt"            '$2'        "$HTP_NEW"
 
 scenario_done

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -53,6 +53,10 @@ assert_contains "auth failure suggests login" "teamvault-cli login" \
 # Basic-auth-safe: raw output has NO trailing newline ("demo-pass-123" = 13 bytes).
 assert_eq "no trailing newline" "13" "$("$TV" password --teamvault-key demo | wc -c | tr -d ' ')"
 
+# htpasswd — derives a user:bcrypt line from the secret's username + password.
+assert_contains "htpasswd user prefix" "demo-user:" "$("$TV" htpasswd --teamvault-key demo)"
+assert_contains "htpasswd is bcrypt"   '$2'         "$("$TV" htpasswd --teamvault-key demo)"
+
 # trailing-slash URL — a config whose url ends in "/" must still resolve (the CLI
 # normalizes it; without that, "<url>//api/secrets/…" 404s). This is the exact
 # value a user copies from the browser.


### PR DESCRIPTION
## What

Adds `teamvault-cli htpasswd <KEY>` — prints an htpasswd-format credential (`user:$2…` bcrypt) built from a TeamVault secret's username + password, for secret-free htpasswd generation at deploy time (e.g. `--set-string secrets.htpasswd=$(teamvault-cli htpasswd <KEY>)`).

## Why

Surfaced by the nuke docker-registry deploy: a basic-auth ingress needs an htpasswd secret without storing a pre-computed hash in git. Reusable beyond that case.

## How

- New `pkg/cli/htpasswd.go` — thin cobra subcommand mirroring the secret readers; resolves the key (positional or `--teamvault-key`), builds the existing `HtpasswdGenerator` from the shared `Connector`, writes its bytes verbatim (native htpasswd-file format).
- Reuses `pkg/htpasswd-generator.go` (same bcrypt path as the `teamvaultHtpasswd` config template func) — no duplicated hashing.
- Registered in `NewRootCommand`.

## Tests

- Ginkgo (external `cli_test`, Counterfeiter `Connector` mock): registration, valid key (bcrypt-verifies against the password), connector-error path, missing-key path.
- e2e (`scripts/e2e.sh`): asserts `htpasswd --teamvault-key demo` → `demo-user:$2…` against fakevault.
- `make precommit` green (231/231 specs, 0 lint, 0 vuln, license). `make e2e` green (26 cases).

## Docs

README command-reference row + deployment usage snippet; CHANGELOG `## Unreleased` entry.