### PR TITLE
repo-review: justify nosec and fix an error-message typo at 355e02b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- fix: justify the #nosec G115 directive in isTTYStdin
+- fix: correct "form" typo in the api-url parse error message
+
 ## v5.10.0
 
 - test(e2e): add scenario 009 covering `htpasswd` end-to-end against fakevault (seeded fixture + a freshly created secret)

--- a/pkg/api-url.go
+++ b/pkg/api-url.go
@@ -21,7 +21,7 @@ func (a ApiUrl) String() string {
 func (a ApiUrl) Key() (Key, error) {
 	parts := strings.Split(a.String(), "/")
 	if len(parts) < 3 {
-		return "", fmt.Errorf("parse key form api-url failed")
+		return "", fmt.Errorf("parse key from api-url failed")
 	}
 	return Key(parts[len(parts)-2]), nil
 }

--- a/pkg/cli/writer.go
+++ b/pkg/cli/writer.go
@@ -120,7 +120,9 @@ func (sf *SharedFlags) buildWriter(ctx context.Context) (teamvault.Writer, error
 
 // isTTYStdin returns true if os.Stdin is connected to an interactive terminal.
 func isTTYStdin() bool {
-	return term.IsTerminal(int(os.Stdin.Fd())) // #nosec G115
+	// #nosec G115 -- Fd() returns a small file descriptor (0 for stdin); the
+	// uintptr-to-int conversion cannot overflow on any supported platform.
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 // readPasswordFromStdin reads a password from stdin to EOF. It rejects empty


### PR DESCRIPTION
Repo review at `355e02b`. **856 mechanical findings from 74 rules → 2 fixed.**

## Fixed

**M1 — `#nosec G115` with no justification** (`pkg/cli/writer.go:122`):

```go
return term.IsTerminal(int(os.Stdin.Fd())) // #nosec G115
```

G115 flags integer-overflow-prone conversions. A bare suppression is unreviewable. This one is justified — `Fd()` returns a small file descriptor (0 for stdin), so the `uintptr` → `int` conversion cannot overflow on any supported platform — and the reason is now in the code.

Given this is a **credential-handling tool**, unexplained security suppressions are worth closing out on principle even when each one turns out fine.

**S1 — typo in an error message** (`pkg/api-url.go:23`): *"parse key **form** api-url failed"* → *"from"*.

## Declined — 2 × `no-fmt-errorf`

`pkg/api-url.go:23` and `pkg/normalize-path.go:22`. `bborbe/errors` requires a `ctx`; both are on public functions with none in scope (`func (a ApiUrl) Key() (Key, error)` and `NormalizePath`). Converting means a public API break to thread `ctx` into static-message errors — cost without benefit. Recorded rather than skipped silently.

## Refuted

The bulk falls to the standing triage table. The remainder are the context-cancellation family — assessed against the narrow form, these loops iterate already-fetched in-memory collections — plus naming and shape suggestions identifying no defect.

Checked explicitly for this repo's domain: no credential is logged, and `SentryDSN` masking is not applicable (no such field here).

## Verification

`make precommit` green — **230/230 specs**, 68.1% composite coverage, 0 lint, osv-scanner and trivy both clean. Findings counted after dropping generated sources per `commands/code-review.md` Step 1.